### PR TITLE
Refine hero image bottom gradient

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,9 +140,38 @@ h1, h2, h3 {
   /* (grid removed above) */
 }
 .image-side { flex: 1; overflow: hidden; display: flex; justify-content: flex-start; align-items: center; position: relative; z-index: 1; }
+.image-side::before { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 180px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.75) 70%, rgba(0, 0, 0, 0.95) 100%);
+  pointer-events: none; z-index: 2; }
 .image-side::after { content: ""; position: absolute; left: 0; top: 0; height: 100%; width: 120px;
-  background: linear-gradient(to right, black, transparent); z-index: 2; pointer-events: none; }
-.image-side img { width: 100%; height: 100%; object-fit: cover; position: relative; z-index: 0; transform: translateX(-40px); }
+  background: linear-gradient(to right, black, transparent); z-index: 3; pointer-events: none; }
+.image-side img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: relative;
+  z-index: 0;
+  transform: translateX(-40px);
+  /* soften the bottom edge so the hero image fades into the background */
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) 55%,
+    rgba(0, 0, 0, 0.85) 70%,
+    rgba(0, 0, 0, 0.55) 82%,
+    rgba(0, 0, 0, 0.2) 92%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) 55%,
+    rgba(0, 0, 0, 0.85) 70%,
+    rgba(0, 0, 0, 0.55) 82%,
+    rgba(0, 0, 0, 0.2) 92%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+}
 
 /* Headline */
 .headline { font-size: 3rem; font-weight: 800; line-height: 1.2; }


### PR DESCRIPTION
## Summary
- add a bottom overlay gradient to the hero image so it diffuses smoothly into the dark background
- strengthen the mask gradient stops for a softer fade through multiple levels of transparency
- adjust overlay layering to keep the left edge vignette above the new bottom fade

## Testing
- npm test *(fails: no package.json present for npm scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdd4af55083209394f3c29472bc0b