### PR TITLE
Refine hero presentation and add animated About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,10 @@
 
   <!-- fonts + site CSS -->
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Great+Vibes&family=Inter:wght@400;600;800&display=swap"
+    rel="stylesheet"
+  />
 
   <!-- safety: make sure sections sit above animated bg even if CSS got overridden -->
   <style>
@@ -47,7 +50,7 @@
     <nav class="nav-links">
       <a href="#home">Home</a>
       <a href="#services">Services</a>
-      <a href="about.html">About Us</a>
+      <a href="#about">About Us</a>
       <a href="book.html" class="quote-btn">Book Online</a>
     </nav>
   </header>
@@ -73,6 +76,8 @@
     </div>
 
     <div class="image-side">
+      <div class="image-top-diffuse" aria-hidden="true"></div>
+      <div class="floating-soap" aria-hidden="true">🧼</div>
       <img src="cleanuptransformation.jpg" alt="Cleanup transformation image" />
     </div>
   </section>
@@ -108,6 +113,24 @@
         <p>Clear glass and safe rails at height—performed with scissor lifts (no rope-access). Frames, tracks, and mezzanine rails detailed and sanitized.</p>
         <span class="service-cta">book this</span>
       </a>
+    </div>
+  </section>
+
+  <!-- ABOUT -->
+  <section id="about" class="about-section">
+    <div class="about-inner">
+      <div class="about-content">
+        <p class="about-intro">A quick reminder of who we are</p>
+        <h2 class="about-title">
+          <span class="about-script">about us</span>
+        </h2>
+        <p class="about-slogan">We scrub with heart so your team can focus on what matters.</p>
+        <p class="about-description">
+          <span>Family-built, people-first cleaning crews who respect every facility we enter.</span>
+          <span>We show up on time, finish the tough jobs, and leave every surface ready to shine.</span>
+        </p>
+      </div>
+      <div class="about-soap" aria-hidden="true">🧼</div>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -126,9 +126,11 @@ h1, h2, h3 {
 @keyframes popIn { 0%{transform:scale(.5) rotate(-30deg);opacity:0} 60%{transform:scale(1.3) rotate(10deg);opacity:1} 100%{transform:scale(1.1)} }
 @keyframes fadeInUp { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
 @keyframes sparkle { 0%,100%{opacity:.8;transform:scale(1) rotate(0)} 50%{opacity:1;transform:scale(1.2) rotate(20deg)} }
+@keyframes floatSoap { 0%,100%{transform:translateY(0) rotate(-4deg) scale(1);} 50%{transform:translateY(-12px) rotate(6deg) scale(1.06);} }
 
 /* Nav links */
-.nav-links a { margin-left: 2rem; color: #eee; font-size: 1rem; transition: color .3s ease; }
+.nav-links { display: flex; align-items: center; gap: 1.75rem; }
+.nav-links a { color: #eee; font-size: 1rem; transition: color .3s ease; }
 .nav-links a:hover { color: #00d4ff; }
 
 /* =========================
@@ -145,13 +147,26 @@ h1, h2, h3 {
   pointer-events: none; z-index: 2; }
 .image-side::after { content: ""; position: absolute; left: 0; top: 0; height: 100%; width: 120px;
   background: linear-gradient(to right, black, transparent); z-index: 3; pointer-events: none; }
+.image-top-diffuse { position: absolute; inset: 0 0 auto 0; height: 150px; pointer-events: none; z-index: 3;
+  background: linear-gradient(180deg, rgba(0,0,0,.75) 0%, rgba(0,0,0,.45) 55%, transparent 100%);
+  filter: blur(24px);
+}
+.floating-soap { position: absolute; top: 32px; right: 28px; font-size: 3.4rem; z-index: 4;
+  animation: floatSoap 4.5s ease-in-out infinite; text-shadow: 0 10px 24px rgba(0, 212, 255, 0.25);
+  pointer-events: none;
+}
+.floating-soap::after { content: '✨'; position: absolute; top: -16px; right: -14px; font-size: 1.1rem;
+  animation: sparkle 1.6s ease-in-out infinite; opacity: .9; }
+.floating-soap::before { content: ""; position: absolute; inset: 40% -20% -35% -45%;
+  background: radial-gradient(circle at 50% 50%, rgba(0,212,255,.35), transparent 70%);
+  filter: blur(14px); z-index: -1; }
 .image-side img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   position: relative;
-  z-index: 0;
-  transform: translateX(-40px);
+  z-index: 1;
+  transform: translateX(-80px);
   /* soften the bottom edge so the hero image fades into the background */
   -webkit-mask-image: linear-gradient(
     to bottom,
@@ -187,7 +202,7 @@ h1, h2, h3 {
 /* Subtext & CTAs */
 .subtext { font-size: 1.1rem; margin-top: 2rem; color: #ccc; max-width: 500px; }
 .quote-btn-home {
-  margin-top: 3rem; padding: .8em 2em; background: #00d4ff; color: #000 !important; font-weight: bold;
+  margin-top: 2.4rem; padding: .8em 2em; background: #00d4ff; color: #000 !important; font-weight: bold;
   border: none; border-radius: 14px; font-size: 1.5rem; cursor: pointer; align-self: flex-start;
   animation: fadeInUp 1.5s ease forwards; opacity: 0; transform: translateY(20px);
   transition: background .3s ease, transform .3s ease;
@@ -238,6 +253,43 @@ h1, h2, h3 {
 .service-card p { color:#ccc; line-height:1.6; font-size:1rem; transition: color .3s ease; }
 .service-card:hover p { color:#fff; }
 
+/* =========================
+   ABOUT
+   ========================= */
+.about-section { padding: 6em 2em 7em; position: relative; z-index: 2; }
+.about-inner { max-width: 1100px; margin: 0 auto; display: flex; align-items: flex-start; justify-content: space-between; gap: 3rem;
+  background: rgba(0,0,0,0.55); border: 1px solid rgba(0,212,255,0.25); border-radius: 28px; padding: 3em;
+  box-shadow: 0 40px 90px rgba(0,0,0,0.45);
+}
+.about-content { max-width: 640px; }
+.about-intro { letter-spacing: .35rem; font-size: .85rem; text-transform: uppercase; color: rgba(0,212,255,0.75);
+  margin-bottom: 1rem; animation: fadeInUp .8s ease forwards; opacity: 0; }
+.about-title { margin-bottom: 1.2rem; position: relative; }
+.about-script { font-family: 'Great Vibes', cursive; font-size: 4rem; display: inline-block; text-transform: lowercase;
+  color: #f3fbff; letter-spacing: .1rem; opacity: 0; animation: scriptReveal 1s ease forwards .2s; position: relative; }
+.about-script::after { content: ""; position: absolute; left: 0; bottom: -6px; height: 4px; width: 100%;
+  background: linear-gradient(90deg, rgba(0,212,255,0) 0%, rgba(0,212,255,0.8) 35%, rgba(0,212,255,1) 55%, rgba(0,212,255,0) 100%);
+  transform-origin: left center; transform: scaleX(0); animation: underlineSweep .7s ease forwards .8s;
+  border-radius: 999px;
+}
+.about-slogan { font-size: 1.35rem; color: #d2ebff; line-height: 1.6; margin-bottom: 1.75rem;
+  opacity: 0; animation: fadeInUp 1s ease forwards .6s; max-width: 28ch; }
+.about-description { display: grid; gap: 1rem; color: #cfe9ff; font-size: 1.05rem; line-height: 1.7; }
+.about-description span { display: block; opacity: 0; transform: translateY(12px); animation: textReveal .8s ease forwards; }
+.about-description span:nth-child(1) { animation-delay: .9s; }
+.about-description span:nth-child(2) { animation-delay: 1.15s; }
+.about-soap { font-size: 5rem; color: #00d4ff; position: relative; flex: 1; display: flex; justify-content: flex-end; pointer-events: none; }
+.about-soap::before { content: ""; position: absolute; top: 45%; left: 30%; width: 180px; height: 180px; border-radius: 50%;
+  background: radial-gradient(circle, rgba(0,212,255,.3) 0%, rgba(0,212,255,0) 70%); filter: blur(18px); }
+.about-soap::after { content: '✨'; position: absolute; top: -10px; right: 24px; font-size: 1.5rem;
+  animation: sparkle 1.6s ease-in-out infinite; opacity: .9; }
+.about-soap span { display: none; }
+.about-soap { animation: floatSoap 5s ease-in-out infinite; align-items: flex-start; padding-top: .5rem; }
+
+@keyframes scriptReveal { 0% { opacity: 0; transform: translateY(20px) scale(0.95); } 100% { opacity: 1; transform: translateY(0) scale(1); } }
+@keyframes underlineSweep { from { transform: scaleX(0); opacity: 0; } to { transform: scaleX(1); opacity: 1; } }
+@keyframes textReveal { to { opacity: 1; transform: translateY(0); } }
+
 /* Quote section (unchanged) */
 .quote-form-section { padding: 4em 2em; background: linear-gradient(to bottom, #000, #333); color:#fff; text-align:center; }
 .quote-form-section h1 { font-size: 2.5rem; margin-bottom: 2rem; color:#00d4ff; }
@@ -271,24 +323,21 @@ html.ios .announcement-cta:hover { background:#00cc6d !important; }
 html.ios .split-screen { flex-direction: column; height: auto; }
 html.ios .image-side { display: none !important; }
 html.ios .text-side {
-  background: url('cleanuptransformation.jpg') center center / cover no-repeat;
+  background:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.6) 45%, rgba(0, 0, 0, 0.35) 100%),
+    url('cleanuptransformation.jpg') center center / cover no-repeat;
   min-height: 100svh; padding: 4em 1.5em calc(1.5em + env(safe-area-inset-bottom));
   display:flex; flex-direction:column; justify-content:center; align-items:flex-start;
   border-radius:20px; overflow:hidden; position:relative;
 }
-html.ios .text-side::before {
-  content:""; position:absolute; inset:0 0 auto 0; height:35%;
-  background: linear-gradient(to bottom, rgba(255,255,255,.9), rgba(255,255,255,0));
-  z-index:1; pointer-events:none;
-}
-html.ios .headline { font-size:3rem; line-height:1.15; font-weight:900; color:#000; position:relative; z-index:2; }
-html.ios .subtext { font-size:1.3rem; font-weight:700; color:#000; max-width:30ch; position:relative; z-index:2; }
-html.ios .headline, html.ios .subtext { text-shadow: 0 2px 4px rgba(255,255,255,.65); }
+html.ios .text-side::before { display: none; }
+html.ios .headline { font-size:3rem; line-height:1.15; font-weight:900; color:#f6fbff; position:relative; text-shadow: 0 14px 32px rgba(0,0,0,0.55); }
+html.ios .subtext { font-size:1.3rem; font-weight:600; color:#e4f4ff; max-width:30ch; position:relative; text-shadow: 0 12px 28px rgba(0,0,0,0.45); }
 html.ios .quote-btn-home, html.ios .services-btn-home {
-  background:#00ff88 !important; color:#000 !important; border:none; border-radius:14px; font-weight:800;
-  font-size:1.5rem; padding:.8em 2em; text-transform:lowercase; transition: background .3s ease, transform .3s ease; position:relative; z-index:2;
+  background:#00d4ff !important; color:#001220 !important; border:none; border-radius:14px; font-weight:800;
+  font-size:1.4rem; padding:.8em 2em; text-transform:lowercase; transition: background .3s ease, transform .3s ease; position:relative; z-index:2;
 }
-html.ios .quote-btn-home:hover, html.ios .services-btn-home:hover { background:#00cc6d !important; transform: translateY(-2px); }
+html.ios .quote-btn-home:hover, html.ios .services-btn-home:hover { background:#33e1ff !important; transform: translateY(-2px); }
 html.ios .navbar { z-index: 1003; }
 
 /* Responsive */
@@ -300,6 +349,10 @@ html.ios .navbar { z-index: 1003; }
   .service-image { width: 150px; height: 150px; }
   .navbar { padding: 1em 2em; }
   .logo { font-size: 1.5rem; }
+  .floating-soap { font-size: 2.6rem; top: 18px; right: 18px; }
+  .image-top-diffuse { height: 120px; }
+  .about-inner { flex-direction: column; padding: 2.75em 2em; }
+  .about-soap { align-self: flex-end; margin-top: 2rem; font-size: 4rem; }
 }
 
 /* Orbital (unused but retained) */


### PR DESCRIPTION
## Summary
- stretch the hero photo toward the copy, add a diffused top blur, and layer an animated soap accent on desktop
- tighten desktop navigation spacing and tweak CTA placement while refreshing iOS hero readability
- introduce an animated "About Us" section with cursive reveal text and matching soap sparkle treatment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbeb0ffc708320abcfb248d8abf448