### PR TITLE
Add rotating hero image carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,26 @@
 
     <div class="image-side">
       <div class="image-top-diffuse" aria-hidden="true"></div>
-      <img src="cleanuptransformation.jpg" alt="Cleanup transformation image" />
+      <div class="hero-carousel" id="hero-carousel" role="region" aria-label="Showcase photos">
+        <div class="hero-slide active" data-index="0">
+          <img src="cleanuptransformation.jpg" alt="Cleanup transformation image" />
+        </div>
+        <div class="hero-slide" data-index="1">
+          <img src="IMG_3541.png" alt="Cleaning crew wiping down stainless steel surfaces" />
+        </div>
+        <div class="hero-slide" data-index="2">
+          <img src="IMG_1629.png" alt="Freshly cleaned office lobby with seating area" />
+        </div>
+        <div class="hero-slide" data-index="3">
+          <img src="IMG_1487.png" alt="Sanitized kitchen counter shining under lights" />
+        </div>
+        <div class="hero-dots" role="tablist" aria-label="Hero image navigation">
+          <button type="button" class="hero-dot active" aria-label="Cleanup transformation image" role="tab"></button>
+          <button type="button" class="hero-dot" aria-label="Cleaning crew wiping down stainless steel surfaces" role="tab"></button>
+          <button type="button" class="hero-dot" aria-label="Freshly cleaned office lobby with seating area" role="tab"></button>
+          <button type="button" class="hero-dot" aria-label="Sanitized kitchen counter shining under lights" role="tab"></button>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -266,6 +285,55 @@
         /iP(hone|od|ad)/.test(navigator.platform) ||
         (navigator.userAgent.includes('Mac') && navigator.maxTouchPoints > 1);
       if (iOS) document.documentElement.classList.add('ios');
+    })();
+  </script>
+
+  <!-- Hero image carousel -->
+  <script>
+    (function(){
+      const carousel = document.getElementById('hero-carousel');
+      if(!carousel) return;
+
+      const slides = Array.from(carousel.querySelectorAll('.hero-slide'));
+      const dots = Array.from(carousel.querySelectorAll('.hero-dot'));
+      let index = 0;
+      let timer = null;
+
+      function setActive(next){
+        slides[index].classList.remove('active');
+        slides[index].setAttribute('aria-hidden', 'true');
+        dots[index].classList.remove('active');
+        dots[index].setAttribute('aria-selected', 'false');
+
+        index = (next + slides.length) % slides.length;
+
+        slides[index].classList.add('active');
+        slides[index].setAttribute('aria-hidden', 'false');
+        dots[index].classList.add('active');
+        dots[index].setAttribute('aria-selected', 'true');
+      }
+
+      function next(){ setActive(index + 1); }
+
+      function start(){ stop(); timer = setInterval(next, 5000); }
+      function stop(){ if(timer){ clearInterval(timer); timer = null; } }
+
+      dots.forEach((dot, i)=>{
+        dot.addEventListener('click', ()=>{ setActive(i); start(); });
+        dot.addEventListener('keydown', (evt)=>{
+          if(evt.key === 'Enter' || evt.key === ' '){ evt.preventDefault(); setActive(i); start(); }
+        });
+      });
+
+      carousel.addEventListener('mouseenter', stop);
+      carousel.addEventListener('mouseleave', start);
+      carousel.addEventListener('touchstart', stop, {passive:true});
+      carousel.addEventListener('touchend', ()=>{ start(); }, {passive:true});
+
+      slides.forEach((slide, i)=> slide.setAttribute('aria-hidden', i === index ? 'false' : 'true'));
+      dots.forEach((dot, i)=> dot.setAttribute('aria-selected', i === index ? 'true' : 'false'));
+      setActive(0);
+      start();
     })();
   </script>
 

--- a/style.css
+++ b/style.css
@@ -151,6 +151,13 @@ h1, h2, h3 {
   background: linear-gradient(180deg, rgba(0,0,0,.75) 0%, rgba(0,0,0,.45) 55%, transparent 100%);
   filter: blur(24px);
 }
+.hero-carousel{ position:relative; width:100%; height:100%; }
+.hero-slide{ position:absolute; inset:0; opacity:0; transition: opacity .7s ease; pointer-events:none; }
+.hero-slide.active{ opacity:1; z-index:2; pointer-events:auto; }
+.hero-slide img{ width:100%; height:100%; object-fit:cover; position:relative; z-index:1; transform:translateX(-80px); -webkit-mask-image:linear-gradient(to bottom, rgba(0,0,0,1) 55%, rgba(0,0,0,0.85) 70%, rgba(0,0,0,0.55) 82%, rgba(0,0,0,0.2) 92%, rgba(0,0,0,0) 100%); mask-image:linear-gradient(to bottom, rgba(0,0,0,1) 55%, rgba(0,0,0,0.85) 70%, rgba(0,0,0,0.55) 82%, rgba(0,0,0,0.2) 92%, rgba(0,0,0,0) 100%); -webkit-mask-size:100% 100%; mask-size:100% 100%; }
+.hero-dots{ position:absolute; left:50%; bottom:28px; transform:translateX(-50%); display:flex; gap:.6rem; z-index:4; }
+.hero-dot{ width:11px; height:11px; border-radius:50%; border:1.5px solid rgba(0,212,255,.8); background:rgba(0,0,0,0.35); box-shadow:0 0 12px rgba(0,212,255,0.25); cursor:pointer; opacity:.7; transition: opacity .2s ease, transform .2s ease, background-color .2s ease; }
+.hero-dot.active{ background:#00d4ff; opacity:1; transform:scale(1.1); }
 .floating-soap { position: absolute; top: 32px; right: 28px; font-size: 3.4rem; z-index: 4;
   animation: floatSoap 4.5s ease-in-out infinite; text-shadow: 0 10px 24px rgba(0, 212, 255, 0.25);
   pointer-events: none;
@@ -166,26 +173,6 @@ h1, h2, h3 {
   object-fit: cover;
   position: relative;
   z-index: 1;
-  transform: translateX(-80px);
-  /* soften the bottom edge so the hero image fades into the background */
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 1) 55%,
-    rgba(0, 0, 0, 0.85) 70%,
-    rgba(0, 0, 0, 0.55) 82%,
-    rgba(0, 0, 0, 0.2) 92%,
-    rgba(0, 0, 0, 0) 100%
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 1) 55%,
-    rgba(0, 0, 0, 0.85) 70%,
-    rgba(0, 0, 0, 0.55) 82%,
-    rgba(0, 0, 0, 0.2) 92%,
-    rgba(0, 0, 0, 0) 100%
-  );
-  -webkit-mask-size: 100% 100%;
-  mask-size: 100% 100%;
 }
 
 /* Headline */


### PR DESCRIPTION
## Summary
- convert the hero image into a four-frame carousel using the new photos and dot navigation
- style the hero carousel and dot controls to overlay on the right-side image panel
- add JavaScript to auto-rotate the slides with hover/touch pause and accessible keyboard support

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e04cabe4ec8320970fe829aca48090