### PR TITLE
Remove hero banner and tighten quote add-ons

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,52 +66,6 @@
       object-position: right center !important;
     }
 
-    /* ===== Rotator card (with slide animations) ===== */
-    .rotator-card{
-      margin-top: 1.25rem;
-      padding: 1.4rem 1.6rem;
-      max-width: 560px;
-      border-radius: 20px;
-      border:1px solid rgba(0,212,255,0.25);
-      background: rgba(0,0,0,0.55);
-      box-shadow: 0 20px 60px rgba(0,0,0,0.45), 0 0 22px rgba(0,212,255,0.12);
-      backdrop-filter: blur(8px);
-      overflow: hidden;
-      position: relative;
-    }
-    .rotator-window{ position:relative; height:auto; min-height: 84px; }
-    .rotator-line{
-      position:absolute; left:0; top:0; width:100%;
-      opacity:0; transform: translateX(24px);
-      transition: transform .45s ease, opacity .45s ease;
-      will-change: transform, opacity;
-    }
-    .rotator-line.active{ opacity:1; transform: translateX(0); }
-    .rotator-title{
-      display:block; font-family:'Bebas Neue',sans-serif; text-transform:uppercase;
-      letter-spacing:.08em; font-size:1.05rem; color:rgba(0,212,255,0.85); margin-bottom:.25rem;
-    }
-    .rotator-text{ display:block; font-size:1.2rem; line-height:1.65; color:#d8ecff; }
-
-    .rotator-underline{
-      display:block; height:3px; width:100%; border-radius:999px; margin-top:.75rem;
-      background:linear-gradient(90deg, rgba(0,212,255,0), rgba(0,212,255,.85), rgba(255,255,255,0));
-      transform-origin:left center; animation: underlineGrow .6s ease both;
-    }
-    @keyframes underlineGrow{ from{ transform:scaleX(0); opacity:.4;} to{ transform:scaleX(1); opacity:1;} }
-
-    .rotator-dots{ display:flex; gap:.5rem; margin-top:.45rem; }
-    .rotator-dots .dot{
-      width:10px; height:10px; border-radius:50%; border:1.5px solid #00d4ff;
-      background:transparent; opacity:.7; cursor:pointer;
-      transition: transform .2s ease, opacity .2s ease, background-color .2s ease;
-    }
-    .rotator-dots .dot.active{ background:#00d4ff; opacity:1; transform:scale(1.05); }
-
-    /* Slight nudge of whole card on change for “box is moving” feel */
-    .rotator-card.bump{ animation: cardBump .35s ease; }
-    @keyframes cardBump{ 0%{ transform:translateX(0);} 40%{ transform:translateX(6px);} 100%{ transform:translateX(0);} }
-
     /* ===== ABOUT (restored) ===== */
     .about-section { padding: 6em 2em 7em; }
     .about-inner{
@@ -159,43 +113,192 @@
     </nav>
   </header>
 
-  <!-- Announcement -->
-  <div class="announcement" role="region" aria-label="Promotion">
-    <div class="announcement-inner">
-      <p class="announce-line">999-999-999</p>
-      <a class="announcement-cta" href="tel:+1999999999">Call Today</a>
-    </div>
-  </div>
-
   <!-- HERO -->
   <section id="home" class="split-screen">
     <div class="text-side">
-      <h1 class="headline">
-        <span>We</span> <span>Scrub</span> <span>You</span> <span>Shine</span>
-        <img src="cleanerguy.png" alt="Cleaner" class="headline-image" />
-      </h1>
+      <div id="quote" class="hero-quote" aria-labelledby="quote-title">
+        <div class="quote-card">
+          <div class="quote-card-header">
+            <h2 id="quote-title">custom cleaning quote</h2>
+            <p>Answer a few quick questions to unlock a tailored estimate for your space.</p>
+          </div>
 
-      <!-- Rotating service lines (moving box) -->
-      <div class="rotator-card" id="service-rotator">
-        <div class="rotator-window" aria-live="polite">
-          <div class="rotator-line active" data-title="Residential Homes">
-            <span class="rotator-title">Residential Homes</span>
-            <span class="rotator-text">We don’t just tidy houses. We deep clean homes.</span>
-          </div>
-          <div class="rotator-line" data-title="Commercial Buildings">
-            <span class="rotator-title">Commercial Buildings</span>
-            <span class="rotator-text">Commercial spaces collect more than dust. We remove it all.</span>
-          </div>
-          <div class="rotator-line" data-title="Offices / Workspaces">
-            <span class="rotator-title">Offices / Workspaces</span>
-            <span class="rotator-text">Clean offices look professional. Deep clean offices stay professional.</span>
-          </div>
-        </div>
-        <span class="rotator-underline" aria-hidden="true"></span>
-        <div class="rotator-dots" role="tablist" aria-label="Service types">
-          <button class="dot active" aria-label="Residential Homes" role="tab"></button>
-          <button class="dot" aria-label="Commercial Buildings" role="tab"></button>
-          <button class="dot" aria-label="Offices / Workspaces" role="tab"></button>
+          <form id="instant-quote" class="quote-form" novalidate>
+            <div class="quote-grid">
+              <label class="field" for="quote-first-name">
+                <span class="field-label">First Name</span>
+                <input id="quote-first-name" name="first-name" type="text" placeholder="e.g. Jordan" autocomplete="given-name" data-required>
+              </label>
+
+              <label class="field" for="quote-email">
+                <span class="field-label">Email</span>
+                <input id="quote-email" name="email" type="email" placeholder="you@example.com" autocomplete="email" data-required>
+              </label>
+
+              <label class="field" for="quote-service">
+                <span class="field-label">Type of Cleaning Service</span>
+                <select id="quote-service" name="service" data-required>
+                  <option value="" disabled selected>Select a service</option>
+                  <option value="home">Home General Cleaning</option>
+                  <option value="commercial">Factory / Commercial / Industrial Cleaning</option>
+                  <option value="office">Office Workspace Cleaning</option>
+                </select>
+              </label>
+
+              <label class="field" for="quote-square-footage">
+                <span class="field-label">Square Footage</span>
+                <select id="quote-square-footage" name="square-footage" data-required>
+                  <option value="" disabled selected>Select the range</option>
+                  <option value="1000-1500">1,000 – 1,500 sq ft</option>
+                  <option value="1500-2000">1,500 – 2,000 sq ft</option>
+                  <option value="2000-2500">2,000 – 2,500 sq ft</option>
+                  <option value="2500-3000">2,500 – 3,000 sq ft</option>
+                  <option value="3000-3500">3,000 – 3,500 sq ft</option>
+                  <option value="3500-4000">3,500 – 4,000 sq ft</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="quote-summary" aria-live="polite">
+              <div class="quote-summary-line">
+                <span>Base Estimate</span>
+                <strong id="quote-base-price">—</strong>
+              </div>
+              <div class="quote-summary-line total">
+                <span>Total with Customizations</span>
+                <strong id="quote-total-price">—</strong>
+              </div>
+            </div>
+
+            <div id="quote-customize" class="quote-customize" aria-hidden="true">
+              <div class="customize-heading" role="status">Customize your cleaning</div>
+
+              <div class="addon-groups">
+                <div class="addon-group" data-service-group="home">
+                  <p class="addon-group-title">Home &amp; Residential Extras</p>
+                  <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
+                    <span class="addon-icon">✨</span>
+                    <span class="addon-name">Deep Clean Package</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
+                  </div>
+                  <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
+                    <span class="addon-icon">🚚</span>
+                    <span class="addon-name">Move In/Out Clean Package</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
+                  </div>
+                  <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
+                    <span class="addon-icon">🛠️</span>
+                    <span class="addon-name">Renovation Clean Package</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
+                  </div>
+                  <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
+                    <span class="addon-icon">🎓</span>
+                    <span class="addon-name">Move In/Out Package (Student Property)</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
+                  </div>
+                  <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
+                    <span class="addon-icon">🏠</span>
+                    <span class="addon-name">AirBnB Listing</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
+                  </div>
+                  <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
+                    <span class="addon-icon">🐾</span>
+                    <span class="addon-name">I have Pets</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
+                  </div>
+                  <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
+                    <span class="addon-icon">🧊</span>
+                    <span class="addon-name">Inside Fridge</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
+                  </div>
+                  <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
+                    <span class="addon-icon">🔥</span>
+                    <span class="addon-name">Inside Oven</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
+                  </div>
+                  <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
+                    <span class="addon-icon">🗄️</span>
+                    <span class="addon-name">Inside Cabinets</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
+                  </div>
+                  <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
+                    <span class="addon-icon">🍽️</span>
+                    <span class="addon-name">Additional Kitchen</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
+                  </div>
+                  <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
+                    <span class="addon-icon">🪟</span>
+                    <span class="addon-name">Blinds (per window)</span>
+                    <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
+                  </div>
+                  <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
+                    <span class="addon-icon">🔍</span>
+                    <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
+                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
+                  </div>
+                  <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
+                    <span class="addon-icon">🔎</span>
+                    <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
+                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
+                  </div>
+                  <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
+                    <span class="addon-icon">🪟</span>
+                    <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
+                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
+                  </div>
+                  <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
+                    <span class="addon-icon">🛏️</span>
+                    <span class="addon-name">Change Bed Sheets + Load Laundry</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
+                  </div>
+                  <div class="addon-pill color-crimson" data-addon="Load dishwasher" data-price="10">
+                    <span class="addon-icon">🍽️</span>
+                    <span class="addon-name">Load Dishwasher</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
+                  </div>
+                  <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
+                    <span class="addon-icon">🧴</span>
+                    <span class="addon-name">Sanitization Package</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
+                  </div>
+                </div>
+
+                <div class="addon-group" data-service-group="commercial,office">
+                  <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
+                  <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
+                    <span class="addon-icon">🧼</span>
+                    <span class="addon-name">Carpet Steam Cleaning Package</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
+                  </div>
+                  <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
+                    <span class="addon-icon">🧽</span>
+                    <span class="addon-name">Tile and Grout Cleaning Package</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout Cleaning quantity">
+                  </div>
+                  <div class="addon-pill color-mint" data-addon="Restock Bathroom Supply" data-price="40">
+                    <span class="addon-icon">🧻</span>
+                    <span class="addon-name">Restock Bathroom Supply</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Restock Bathroom Supply quantity">
+                  </div>
+                  <div class="addon-pill color-gold" data-addon="Disinfect Electronics" data-price="45">
+                    <span class="addon-icon">💻</span>
+                    <span class="addon-name">Disinfect Electronics</span>
+                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Disinfect Electronics quantity">
+                  </div>
+                  <div class="addon-pill color-teal" data-addon="Empty Garbage/Recycling" data-price="18">
+                    <span class="addon-icon">🗑️</span>
+                    <span class="addon-name">Empty Garbage/Recycling</span>
+                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Empty Garbage/Recycling quantity">
+                  </div>
+                  <div class="addon-pill color-lime" data-addon="Water Plants" data-price="15">
+                    <span class="addon-icon">🌿</span>
+                    <span class="addon-name">Water Plants</span>
+                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Water Plants quantity">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
         </div>
       </div>
 
@@ -278,6 +381,191 @@
     </div>
   </section>
 
+  <!-- Quote logic -->
+  <script>
+    (function(){
+      const form = document.getElementById('instant-quote');
+      if(!form) return;
+
+      const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
+      const basePriceEl = document.getElementById('quote-base-price');
+      const totalPriceEl = document.getElementById('quote-total-price');
+      const customizeBlock = document.getElementById('quote-customize');
+      const serviceSelect = document.getElementById('quote-service');
+      const sqftSelect = document.getElementById('quote-square-footage');
+      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
+      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+
+      const basePricing = {
+        home: {
+          '1000-1500': 165,
+          '1500-2000': 185,
+          '2000-2500': 215,
+          '2500-3000': 245,
+          '3000-3500': 285,
+          '3500-4000': 325
+        },
+        commercial: {
+          '1000-1500': 240,
+          '1500-2000': 285,
+          '2000-2500': 330,
+          '2500-3000': 380,
+          '3000-3500': 425,
+          '3500-4000': 470
+        },
+        office: {
+          '1000-1500': 210,
+          '1500-2000': 250,
+          '2000-2500': 295,
+          '2500-3000': 335,
+          '3000-3500': 375,
+          '3500-4000': 420
+        }
+      };
+
+      function hasAllRequired(){
+        return requiredFields.every(field => {
+          if(field.type === 'email'){
+            return field.value.trim() !== '' && field.value.includes('@');
+          }
+          return field.value.trim() !== '';
+        });
+      }
+
+      function resetAddons(){
+        addonPills.forEach(pill => {
+          pill.classList.remove('active');
+          const qty = pill.querySelector('.addon-qty');
+          if(qty){
+            qty.value = 1;
+            qty.disabled = true;
+          }
+          pill.setAttribute('aria-pressed', 'false');
+        });
+      }
+
+      function updateAddonAvailability(serviceKey){
+        addonGroups.forEach(group => {
+          const services = group.dataset.serviceGroup.split(',');
+          const match = services.includes(serviceKey);
+          group.classList.toggle('active', match);
+        });
+
+        addonPills.forEach(pill => {
+          const parent = pill.closest('.addon-group');
+          const enabled = parent && parent.classList.contains('active');
+          pill.style.display = enabled ? '' : 'none';
+          if(!enabled){
+            pill.classList.remove('active');
+            const qty = pill.querySelector('.addon-qty');
+            if(qty){
+              qty.value = 1;
+              qty.disabled = true;
+            }
+            pill.setAttribute('aria-pressed', 'false');
+          }
+        });
+      }
+
+      function calculateTotal(){
+        const serviceKey = serviceSelect.value;
+        const sqftKey = sqftSelect.value;
+        if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
+          basePriceEl.textContent = '—';
+          totalPriceEl.textContent = '—';
+          return;
+        }
+
+        const base = basePricing[serviceKey][sqftKey] || 0;
+        let total = base;
+
+        addonPills.forEach(pill => {
+          if(!pill.classList.contains('active')) return;
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+
+          const price = Number(pill.dataset.price || 0);
+          const qtyInput = pill.querySelector('.addon-qty');
+          const qty = qtyInput ? Math.max(1, Number(qtyInput.value) || 1) : 1;
+          total += price * qty;
+        });
+
+        basePriceEl.textContent = base ? `$${base.toFixed(0)}` : '—';
+        totalPriceEl.textContent = total ? `$${total.toFixed(0)}` : '—';
+      }
+
+      function toggleCustomize(){
+        const ready = hasAllRequired();
+        customizeBlock.classList.toggle('visible', ready);
+        customizeBlock.setAttribute('aria-hidden', ready ? 'false' : 'true');
+        form.classList.toggle('quote-ready', ready);
+        if(!ready){
+          basePriceEl.textContent = '—';
+          totalPriceEl.textContent = '—';
+          resetAddons();
+        } else {
+          updateAddonAvailability(serviceSelect.value);
+          calculateTotal();
+        }
+      }
+
+      addonPills.forEach(pill => {
+        pill.addEventListener('click', (event) => {
+          if(!customizeBlock.classList.contains('visible')) return;
+          const qtyInput = pill.querySelector('.addon-qty');
+          if(event.target === qtyInput) return;
+
+          pill.classList.toggle('active');
+          if(qtyInput){
+            qtyInput.disabled = !pill.classList.contains('active');
+          }
+          pill.setAttribute('aria-pressed', pill.classList.contains('active') ? 'true' : 'false');
+          calculateTotal();
+        });
+
+        const qtyInput = pill.querySelector('.addon-qty');
+        if(qtyInput){
+          qtyInput.disabled = true;
+          qtyInput.addEventListener('input', () => {
+            if(!pill.classList.contains('active')) return;
+            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min)){
+              qtyInput.value = qtyInput.min;
+            }
+            calculateTotal();
+          });
+        }
+
+        pill.addEventListener('keydown', (evt) => {
+          if(evt.key === 'Enter' || evt.key === ' '){
+            evt.preventDefault();
+            pill.click();
+          }
+        });
+        pill.setAttribute('tabindex', '0');
+        pill.setAttribute('role', 'button');
+        pill.setAttribute('aria-pressed', 'false');
+      });
+
+      requiredFields.forEach(field => {
+        const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
+        field.addEventListener(eventName, toggleCustomize);
+      });
+
+      serviceSelect.addEventListener('change', () => {
+        updateAddonAvailability(serviceSelect.value);
+        calculateTotal();
+      });
+
+      sqftSelect.addEventListener('change', calculateTotal);
+
+      addonPills.forEach(pill => {
+        pill.setAttribute('aria-pressed', 'false');
+      });
+
+      toggleCustomize();
+    })();
+  </script>
+
   <!-- iOS detector -->
   <script>
     (function () {
@@ -337,57 +625,5 @@
     })();
   </script>
 
-  <!-- Rotator logic (slide + bump + swipe) -->
-  <script>
-    (function(){
-      const box = document.getElementById('service-rotator');
-      if(!box) return;
-
-      const slides = Array.from(box.querySelectorAll('.rotator-line'));
-      const dots   = Array.from(box.querySelectorAll('.rotator-dots .dot'));
-      const underline = box.querySelector('.rotator-underline');
-      let idx = 0, timer = null, touchStartX = 0;
-
-      function show(n, bump=true){
-        // remove current
-        slides[idx].classList.remove('active');
-        dots[idx].classList.remove('active');
-
-        // set new
-        idx = (n + slides.length) % slides.length;
-        slides[idx].classList.add('active');
-        dots[idx].classList.add('active');
-
-        // restart underline anim
-        underline.style.animation = 'none';
-        requestAnimationFrame(()=>{ underline.style.animation = ''; });
-
-        // nudge the whole box so it feels like it moved
-        if(bump){ box.classList.remove('bump'); void box.offsetWidth; box.classList.add('bump'); }
-      }
-
-      function next(){ show(idx+1); }
-      function start(){ stop(); timer = setInterval(next, 4200); }
-      function stop(){ if(timer){ clearInterval(timer); timer=null; } }
-
-      // dots
-      dots.forEach((d,i)=> d.addEventListener('click', ()=>{ show(i); start(); }));
-
-      // swipe
-      box.addEventListener('touchstart', e=>{ touchStartX = e.touches[0].clientX; }, {passive:true});
-      box.addEventListener('touchend', e=>{
-        const dx = e.changedTouches[0].clientX - touchStartX;
-        if(Math.abs(dx) > 40){ show(idx + (dx<0 ? 1 : -1)); start(); }
-      }, {passive:true});
-
-      // hover pause (desktop)
-      box.addEventListener('mouseenter', stop);
-      box.addEventListener('mouseleave', start);
-
-      // init
-      slides.forEach((s,i)=> s.style.zIndex = String(10 - i));
-      show(0,false); start();
-    })();
-  </script>
 </body>
 </html>

--- a/quote-widget.html
+++ b/quote-widget.html
@@ -1,0 +1,544 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cleaning Service Quote Widget</title>
+  <style>
+    :root {
+      --bg-color: radial-gradient(circle at top, rgba(92,117,255,0.25), rgba(16,28,44,0.95));
+      --glass-bg: rgba(255, 255, 255, 0.12);
+      --glass-border: rgba(255, 255, 255, 0.35);
+      --text-primary: #f5f8ff;
+      --text-secondary: rgba(245, 248, 255, 0.68);
+      --accent: linear-gradient(135deg, #76a9ff, #a073ff);
+      --accent-strong: #7191ff;
+      --shadow-soft: 0 24px 40px rgba(15, 22, 46, 0.35);
+      --blur-radius: 20px;
+      --transition: 220ms ease;
+      --pill-bg: rgba(255,255,255,0.08);
+      --pill-bg-active: rgba(118,169,255,0.25);
+      --pill-border: rgba(255,255,255,0.14);
+      --addon-glow: rgba(118, 169, 255, 0.35);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2.5rem 1.5rem;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      background: var(--bg-color);
+      color: var(--text-primary);
+    }
+
+    .widget-shell {
+      position: relative;
+      text-align: center;
+      width: min(500px, 100%);
+    }
+
+    .cta-button {
+      width: 100%;
+      padding: 1.2rem 1.5rem;
+      font-size: 1.1rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      color: #0a1020;
+      background: var(--accent);
+      border: none;
+      border-radius: 16px;
+      cursor: pointer;
+      box-shadow: var(--shadow-soft);
+      transition: transform var(--transition), box-shadow var(--transition);
+    }
+
+    .cta-button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 30px 50px rgba(31, 61, 118, 0.4);
+    }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(12px);
+      background: rgba(5, 12, 24, 0.42);
+      padding: 1.5rem;
+      z-index: 1000;
+    }
+
+    .overlay.active {
+      display: flex;
+      animation: fadeIn var(--transition);
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .panel {
+      width: min(620px, 100%);
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      border-radius: 24px;
+      box-shadow: var(--shadow-soft);
+      backdrop-filter: blur(var(--blur-radius));
+      padding: clamp(1.5rem, 4vw, 2.4rem);
+      position: relative;
+      color: var(--text-primary);
+      overflow: hidden;
+    }
+
+    .panel::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: radial-gradient(circle at top right, rgba(141, 173, 255, 0.18), transparent 60%);
+    }
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1.2rem;
+    }
+
+    .panel-header h2 {
+      margin: 0;
+      font-size: clamp(1.4rem, 3vw, 1.8rem);
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+
+    .close-button {
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.15);
+      color: var(--text-primary);
+      border-radius: 999px;
+      width: 40px;
+      height: 40px;
+      display: grid;
+      place-items: center;
+      font-size: 1.2rem;
+      cursor: pointer;
+      transition: background var(--transition), transform var(--transition);
+    }
+
+    .close-button:hover {
+      background: rgba(255,255,255,0.15);
+      transform: rotate(90deg) scale(1.05);
+    }
+
+    .steps {
+      display: grid;
+      gap: 1.6rem;
+    }
+
+    .step h3 {
+      margin: 0 0 0.75rem;
+      font-size: 1rem;
+      font-weight: 500;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .pill-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+    }
+
+    .pill {
+      padding: 0.65rem 1.3rem;
+      border-radius: 999px;
+      border: 1px solid var(--pill-border);
+      background: var(--pill-bg);
+      color: var(--text-primary);
+      cursor: pointer;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      transition: background var(--transition), border var(--transition), transform var(--transition), box-shadow var(--transition);
+    }
+
+    .pill:hover {
+      border-color: rgba(255,255,255,0.35);
+      transform: translateY(-1px);
+      box-shadow: 0 15px 30px rgba(14, 24, 42, 0.25);
+    }
+
+    .pill.active {
+      background: var(--pill-bg-active);
+      border-color: rgba(113, 145, 255, 0.6);
+      box-shadow: inset 0 0 0 1px rgba(113, 145, 255, 0.4);
+    }
+
+    .price-summary {
+      margin-top: 0.5rem;
+      border-radius: 20px;
+      padding: 1.4rem;
+      border: 1px solid rgba(255,255,255,0.22);
+      background: rgba(255,255,255,0.08);
+      backdrop-filter: blur(18px);
+      box-shadow: 0 20px 40px rgba(12, 18, 33, 0.45);
+      display: none;
+      flex-direction: column;
+      gap: 0.75rem;
+      text-align: left;
+    }
+
+    .price-summary.visible {
+      display: flex;
+      animation: priceFade var(--transition) ease-out;
+    }
+
+    @keyframes priceFade {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .price-summary h4 {
+      margin: 0;
+      font-size: 1.35rem;
+      font-weight: 600;
+    }
+
+    .price-summary p {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+    }
+
+    .addons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 0.5rem;
+    }
+
+    .addon {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.55rem 0.95rem;
+      border-radius: 14px;
+      background: rgba(255,255,255,0.05);
+      border: 1px solid rgba(255,255,255,0.15);
+      box-shadow: 0 12px 22px rgba(12, 18, 33, 0.35);
+      cursor: pointer;
+      transition: transform var(--transition), box-shadow var(--transition), border var(--transition), background var(--transition);
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .addon::after {
+      content: "";
+      position: absolute;
+      inset: -40% -50%;
+      background: radial-gradient(circle, rgba(118,169,255,0.2), transparent 60%);
+      opacity: 0;
+      transition: opacity var(--transition);
+    }
+
+    .addon:hover::after {
+      opacity: 1;
+    }
+
+    .addon:hover {
+      transform: translateY(-2px);
+      border-color: rgba(118,169,255,0.6);
+      box-shadow: 0 20px 35px rgba(15, 24, 52, 0.45);
+    }
+
+    .addon.active {
+      background: rgba(118,169,255,0.12);
+      color: var(--text-primary);
+      border-color: rgba(118,169,255,0.8);
+      box-shadow: 0 0 25px rgba(118,169,255,0.35);
+    }
+
+    .addon-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      background: rgba(118,169,255,0.25);
+      color: var(--text-primary);
+      font-size: 0.75rem;
+    }
+
+    .total-price {
+      font-size: clamp(2rem, 5vw, 2.6rem);
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      color: #ffffff;
+    }
+
+    .subline {
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+    }
+
+    .pill-group[data-columns="2"] {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+      gap: 0.65rem;
+    }
+
+    .panel-footer {
+      margin-top: 1.4rem;
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+    }
+
+    @media (max-width: 540px) {
+      body {
+        padding: 1.5rem 1rem;
+      }
+
+      .panel {
+        border-radius: 20px;
+        padding: 1.4rem;
+      }
+
+      .panel-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+      }
+
+      .close-button {
+        align-self: flex-end;
+      }
+
+      .steps {
+        gap: 1.3rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="widget-shell">
+    <button class="cta-button" id="openQuote">See Price</button>
+  </div>
+
+  <div class="overlay" id="quoteOverlay" aria-hidden="true">
+    <div class="panel" role="dialog" aria-modal="true" aria-labelledby="quoteTitle">
+      <div class="panel-header">
+        <h2 id="quoteTitle">Instant Cleaning Quote</h2>
+        <button class="close-button" id="closeQuote" aria-label="Close quote">×</button>
+      </div>
+
+      <div class="steps">
+        <section class="step" aria-labelledby="bedBathTitle">
+          <h3 id="bedBathTitle">Step 1 · Home Layout</h3>
+          <p class="subline">Select the number of bedrooms and bathrooms.</p>
+          <div class="pill-group" data-type="bedrooms" aria-label="Bedrooms">
+            <button class="pill" data-value="1">1 Bedroom</button>
+            <button class="pill" data-value="2">2 Bedrooms</button>
+            <button class="pill" data-value="3">3 Bedrooms</button>
+            <button class="pill" data-value="4">4 Bedrooms</button>
+            <button class="pill" data-value="5">5 Bedrooms</button>
+            <button class="pill" data-value="6">6 Bedrooms</button>
+          </div>
+          <div class="pill-group" data-type="bathrooms" aria-label="Bathrooms">
+            <button class="pill" data-value="1">1 Bathroom</button>
+            <button class="pill" data-value="2">2 Bathrooms</button>
+            <button class="pill" data-value="3">3 Bathrooms</button>
+            <button class="pill" data-value="4">4 Bathrooms</button>
+          </div>
+        </section>
+
+        <section class="step" aria-labelledby="sqftTitle">
+          <h3 id="sqftTitle">Step 2 · Square Footage</h3>
+          <p class="subline">Choose the size range of your space.</p>
+          <div class="pill-group" data-columns="2" data-type="squareFootage" aria-label="Square footage">
+            <button class="pill" data-value="1250">1000 – 1500 sq ft</button>
+            <button class="pill" data-value="1750">1500 – 2000 sq ft</button>
+            <button class="pill" data-value="2250">2000 – 2500 sq ft</button>
+            <button class="pill" data-value="2750">2500 – 3000 sq ft</button>
+            <button class="pill" data-value="3250">3000 – 3500 sq ft</button>
+            <button class="pill" data-value="3750">3500 – 4000 sq ft</button>
+          </div>
+        </section>
+
+        <section class="price-summary" id="priceSummary" aria-live="polite">
+          <div>
+            <h4>Estimated Total</h4>
+            <div class="total-price" id="totalPrice">$0</div>
+            <p class="subline" id="priceBreakdown">Choose your details to see pricing.</p>
+          </div>
+          <div>
+            <p class="subline">Add-ons</p>
+            <div class="addons" id="addonList">
+              <button class="addon" data-addon="fridge" data-price="25">
+                <span class="addon-icon">🥶</span>
+                <span>Inside Fridge (+$25)</span>
+              </button>
+              <button class="addon" data-addon="oven" data-price="30">
+                <span class="addon-icon">🔥</span>
+                <span>Inside Oven (+$30)</span>
+              </button>
+              <button class="addon" data-addon="carpet" data-price="45">
+                <span class="addon-icon">🧼</span>
+                <span>Deep Carpet Cleaning (+$45)</span>
+              </button>
+              <button class="addon" data-addon="windows" data-price="35">
+                <span class="addon-icon">🪟</span>
+                <span>Windows (+$35)</span>
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="panel-footer">No payment required now — we’ll confirm everything after you submit.</div>
+    </div>
+  </div>
+
+  <script>
+    const openQuoteBtn = document.getElementById('openQuote');
+    const closeQuoteBtn = document.getElementById('closeQuote');
+    const overlay = document.getElementById('quoteOverlay');
+    const priceSummary = document.getElementById('priceSummary');
+    const totalPriceEl = document.getElementById('totalPrice');
+    const priceBreakdownEl = document.getElementById('priceBreakdown');
+    const addonList = document.getElementById('addonList');
+
+    const selections = {
+      bedrooms: null,
+      bathrooms: null,
+      squareFootage: null,
+      addons: new Set()
+    };
+
+    const baseRates = {
+      bedroom: 35,
+      bathroom: 28,
+      base: 110,
+      sqftFactor: 0.04
+    };
+
+    const addonRates = {
+      fridge: 25,
+      oven: 30,
+      carpet: 45,
+      windows: 35
+    };
+
+    function toggleOverlay(open) {
+      overlay.classList.toggle('active', open);
+      overlay.setAttribute('aria-hidden', String(!open));
+      if (open) {
+        document.body.style.overflow = 'hidden';
+      } else {
+        document.body.style.overflow = '';
+      }
+    }
+
+    openQuoteBtn.addEventListener('click', () => toggleOverlay(true));
+    closeQuoteBtn.addEventListener('click', () => toggleOverlay(false));
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        toggleOverlay(false);
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && overlay.classList.contains('active')) {
+        toggleOverlay(false);
+      }
+    });
+
+    function handlePillGroupClick(event) {
+      const target = event.target.closest('.pill');
+      if (!target) return;
+      const group = event.currentTarget;
+      const type = group.dataset.type;
+
+      group.querySelectorAll('.pill').forEach(pill => pill.classList.remove('active'));
+      target.classList.add('active');
+      selections[type] = Number(target.dataset.value);
+      updatePrice();
+    }
+
+    document.querySelectorAll('.pill-group').forEach(group => {
+      const type = group.dataset.type;
+      if (type) {
+        group.addEventListener('click', handlePillGroupClick);
+      }
+    });
+
+    addonList.addEventListener('click', (event) => {
+      const addonButton = event.target.closest('.addon');
+      if (!addonButton) return;
+      const addonKey = addonButton.dataset.addon;
+
+      if (selections.addons.has(addonKey)) {
+        selections.addons.delete(addonKey);
+        addonButton.classList.remove('active');
+      } else {
+        selections.addons.add(addonKey);
+        addonButton.classList.add('active');
+      }
+      updatePrice();
+    });
+
+    function calculateBasePrice() {
+      const { bedrooms, bathrooms, squareFootage } = selections;
+      if (!bedrooms || !bathrooms || !squareFootage) {
+        return null;
+      }
+
+      const layoutCost = baseRates.base + (bedrooms - 1) * baseRates.bedroom + (bathrooms - 1) * baseRates.bathroom;
+      const squareFootageAdjustment = (squareFootage - 1000) * baseRates.sqftFactor;
+      return Math.round(layoutCost + squareFootageAdjustment);
+    }
+
+    function calculateAddonTotal() {
+      let addonTotal = 0;
+      selections.addons.forEach(addonKey => {
+        addonTotal += addonRates[addonKey] || 0;
+      });
+      return addonTotal;
+    }
+
+    function updatePrice() {
+      const basePrice = calculateBasePrice();
+      if (basePrice == null) {
+        priceSummary.classList.remove('visible');
+        priceBreakdownEl.textContent = 'Choose your details to see pricing.';
+        totalPriceEl.textContent = '$0';
+        return;
+      }
+
+      const addonTotal = calculateAddonTotal();
+      const total = basePrice + addonTotal;
+
+      priceSummary.classList.add('visible');
+      totalPriceEl.textContent = `$${total}`;
+
+      const parts = [`Base: $${basePrice}`];
+      if (addonTotal > 0) {
+        parts.push(`Add-ons: +$${addonTotal}`);
+      }
+      priceBreakdownEl.textContent = parts.join(' · ');
+    }
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -139,6 +139,7 @@ h1, h2, h3 {
 .split-screen { display: flex; height: 90vh; width: 100%; position: relative; z-index: 2; }
 .text-side {
   flex: 1; display: flex; flex-direction: column; justify-content: center; padding: 4em;
+  gap: 1.5rem;
   /* (grid removed above) */
 }
 .image-side { flex: 1; overflow: hidden; display: flex; justify-content: flex-start; align-items: center; position: relative; z-index: 1; }
@@ -202,6 +203,311 @@ h1, h2, h3 {
   border: 2px solid #00d4ff; border-radius: 50px; font-size: 1.2rem; align-self: flex-start;
   animation: fadeInUp 1.8s ease forwards; opacity: 0; transform: translateY(20px);
   transition: all .3s ease; text-transform: lowercase;
+}
+
+/* =========================
+   QUOTE PANEL
+   ========================= */
+.hero-quote {
+  margin-top: clamp(1.8rem, 4vw, 2.8rem);
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  align-self: flex-start;
+}
+
+.quote-card {
+  width: 100%;
+  flex: 1;
+  padding: clamp(1.8rem, 3vw, 2.45rem);
+  border-radius: 32px;
+  border: 1.5px solid rgba(0, 212, 255, 0.45);
+  background: linear-gradient(135deg, rgba(8, 19, 30, 0.75), rgba(12, 24, 40, 0.55));
+  box-shadow:
+    0 35px 120px rgba(0, 0, 0, 0.6),
+    0 0 30px rgba(0, 212, 255, 0.25),
+    inset 0 0 35px rgba(0, 212, 255, 0.08);
+  backdrop-filter: blur(16px);
+  position: relative;
+  overflow: hidden;
+}
+
+.quote-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1.5px solid rgba(0, 212, 255, 0.35);
+  pointer-events: none;
+  box-shadow: 0 0 45px rgba(0, 212, 255, 0.2);
+  opacity: 0.6;
+}
+
+.quote-card-header {
+  margin-bottom: 1.75rem;
+}
+
+.quote-card-header h2 {
+  font-size: clamp(1.9rem, 3vw, 2.55rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #e6f8ff;
+  margin-bottom: 0.75rem;
+  text-shadow: 0 0 22px rgba(0, 212, 255, 0.45);
+}
+
+.quote-card-header p {
+  color: rgba(212, 235, 255, 0.78);
+  font-size: 0.98rem;
+  max-width: 32ch;
+}
+
+.quote-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.65rem;
+}
+
+.quote-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.field-label {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(173, 214, 255, 0.85);
+}
+
+.field input,
+.field select {
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1.5px solid rgba(0, 212, 255, 0.25);
+  background: rgba(8, 19, 32, 0.75);
+  color: #f2fbff;
+  font-size: 1rem;
+  box-shadow: inset 0 0 18px rgba(0, 212, 255, 0.06);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: rgba(0, 212, 255, 0.65);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.quote-summary {
+  padding: 1.2rem 1.4rem;
+  border-radius: 24px;
+  background: rgba(10, 22, 34, 0.65);
+  border: 1px solid rgba(0, 212, 255, 0.22);
+  box-shadow: inset 0 0 22px rgba(0, 212, 255, 0.08);
+  display: grid;
+  gap: 0.85rem;
+  opacity: 0.55;
+  transition: opacity 0.35s ease;
+}
+
+.quote-form.quote-ready .quote-summary {
+  opacity: 1;
+}
+
+.quote-summary-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.05rem;
+  color: rgba(214, 238, 255, 0.85);
+}
+
+.quote-summary-line strong {
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+  color: #f7fdff;
+  text-shadow: 0 0 12px rgba(0, 212, 255, 0.35);
+}
+
+.quote-summary-line.total {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.quote-customize {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: max-height 0.6s ease, opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+}
+
+.quote-customize.visible {
+  max-height: 1600px;
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.customize-heading {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: #b5f3ff;
+  text-shadow: 0 0 18px rgba(0, 212, 255, 0.45);
+  margin-bottom: 1.4rem;
+  animation: customizeGlow 1.8s ease-in-out infinite;
+}
+
+@keyframes customizeGlow {
+  0%, 100% { text-shadow: 0 0 18px rgba(0, 212, 255, 0.35), 0 0 36px rgba(76, 198, 255, 0.25); }
+  50% { text-shadow: 0 0 28px rgba(0, 212, 255, 0.55), 0 0 48px rgba(76, 198, 255, 0.35); }
+}
+
+.addon-groups {
+  display: grid;
+  gap: 1rem;
+}
+
+.addon-group-title {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(190, 231, 255, 0.75);
+  margin-bottom: 0.35rem;
+}
+
+.addon-group {
+  display: none;
+}
+
+
+.addon-group.active {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.addon-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(16, 32, 48, 0.6);
+  border: 1px solid rgba(0, 212, 255, 0.18);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  min-width: 0;
+}
+
+.addon-pill:hover {
+  transform: scale(1.04);
+  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.35);
+}
+
+.addon-pill.active {
+  border-color: rgba(0, 212, 255, 0.65);
+  box-shadow: 0 0 0 2px rgba(0, 212, 255, 0.22), 0 16px 28px rgba(0, 0, 0, 0.45);
+}
+
+.addon-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.addon-name {
+  flex: 1;
+  font-size: 0.82rem;
+  color: rgba(226, 245, 255, 0.9);
+  line-height: 1.25;
+  max-width: 11rem;
+  white-space: normal;
+}
+
+.addon-qty {
+  width: 2.6rem;
+  height: 2rem;
+  padding: 0.2rem 0.25rem;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 212, 255, 0.35);
+  background: rgba(6, 20, 32, 0.75);
+  color: #f2fbff;
+  font-size: 0.85rem;
+  text-align: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.addon-qty:focus {
+  outline: none;
+  border-color: rgba(0, 212, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
+}
+
+.addon-pill:not(.active) .addon-qty {
+  opacity: 0.4;
+}
+
+.addon-pill.color-cyan { background: linear-gradient(135deg, rgba(0, 212, 255, 0.32), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-lime { background: linear-gradient(135deg, rgba(159, 255, 99, 0.32), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-magenta { background: linear-gradient(135deg, rgba(255, 99, 189, 0.32), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-orange { background: linear-gradient(135deg, rgba(255, 171, 94, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-indigo { background: linear-gradient(135deg, rgba(138, 138, 255, 0.32), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-gold { background: linear-gradient(135deg, rgba(255, 232, 140, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-sky { background: linear-gradient(135deg, rgba(122, 217, 255, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-rose { background: linear-gradient(135deg, rgba(255, 158, 173, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-mint { background: linear-gradient(135deg, rgba(144, 255, 214, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-teal { background: linear-gradient(135deg, rgba(118, 238, 225, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-plum { background: linear-gradient(135deg, rgba(190, 153, 255, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-azure { background: linear-gradient(135deg, rgba(126, 185, 255, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-amber { background: linear-gradient(135deg, rgba(255, 200, 122, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-blue { background: linear-gradient(135deg, rgba(108, 180, 255, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-lavender { background: linear-gradient(135deg, rgba(215, 177, 255, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-crimson { background: linear-gradient(135deg, rgba(255, 134, 134, 0.35), rgba(10, 30, 48, 0.7)); }
+.addon-pill.color-emerald { background: linear-gradient(135deg, rgba(134, 255, 184, 0.35), rgba(10, 30, 48, 0.7)); }
+
+@media (max-width: 768px) {
+  .hero-quote {
+    max-width: none;
+  }
+
+  .quote-card {
+    padding: 2.25rem 1.75rem;
+  }
+
+  .quote-card-header p {
+    font-size: 0.95rem;
+  }
+
+  .quote-summary {
+    padding: 1.1rem 1.3rem;
+  }
+
+  .addon-pill {
+    flex-wrap: wrap;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .addon-name {
+    flex-basis: 100%;
+    white-space: normal;
+  }
+
+  .addon-qty {
+    width: 100%;
+  }
 }
 .services-btn-home:hover { background:#00d4ff; color:#000; transform: translateY(-2px); box-shadow: 0 8px 20px rgba(0,212,255,.3); }
 


### PR DESCRIPTION
## Summary
- remove the hero announcement strip, headline, and rotating service card so the quote sits directly under the hero intro area
- shrink the customization pills and group spacing so add-ons appear as compact bubbles that stay within the quote panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1399c78b48320bf7761b660050ccd