### PR TITLE
Route instant quote flow to booking extras

### DIFF
--- a/book.html
+++ b/book.html
@@ -6,28 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Book Online — DufferinDeepClean</title>
 
-  <!-- Fonts (match index + About Us script) -->
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;800&family=Great+Vibes&display=swap" rel="stylesheet" />
-
-  <!-- Site CSS (keep your existing file) -->
   <link rel="stylesheet" href="style.css" />
 
-  <!-- Page-specific styles to: 
-       1) match index animated background (slightly darker here),
-       2) unify logo font + animation,
-       3) keep your booking UI exactly as-is otherwise. -->
   <style>
-    /* ===== Animated seamless background (same as index, slightly darker) ===== */
     :root{
-      /* Use the same seamless tile image you use on index */
-      --bg-tile: url('backgroundbook.png');    /* or cleaning-pattern.png if that’s your tile */
+      --bg-tile: url('backgroundbook.png');
       --tile-w: 1536px;
       --tile-h: 1024px;
       --tile-scale: 0.90;
       --tile-w-size: calc(var(--tile-w) * var(--tile-scale));
       --tile-h-size: calc(var(--tile-h) * var(--tile-scale));
-
-      /* Darker overlay than index (index ≈ 0.40/0.66/0.80) */
       --overlay-a: rgba(0,0,0,0.52);
       --overlay-b: rgba(0,0,0,0.78);
       --overlay-c: rgba(0,0,0,0.90);
@@ -40,7 +29,6 @@
       background: transparent !important;
     }
 
-    /* Animated tile layer (under content) */
     body::after{
       content:"";
       position: fixed; inset: 0; z-index: 0; pointer-events: none;
@@ -55,22 +43,18 @@
       to   { background-position: var(--tile-w-size) var(--tile-h-size); }
     }
 
-    /* Darker readability overlay for booking page */
     body::before{
       content:"";
       position: fixed; inset: 0; z-index: 1; pointer-events: none;
-      background: radial-gradient(1200px 600px at 50% -10%,
-                  var(--overlay-a), var(--overlay-b) 60%, var(--overlay-c));
+      background: radial-gradient(1200px 600px at 50% -10%, var(--overlay-a), var(--overlay-b) 60%, var(--overlay-c));
     }
 
-    /* Ensure all content sits above background layers */
     .navbar, main, section, footer { position: relative; z-index: 2; }
 
-    /* ===== NAV: transparent like index, unified logo font + left→right unveil ===== */
     .navbar{
       display:flex; justify-content:space-between; align-items:center;
       padding: 14px 22px;
-      background: rgba(0,0,0,0.20);           /* transparent header over the moving bg */
+      background: rgba(0,0,0,0.20);
       backdrop-filter: blur(6px);
       border-bottom: 1px solid rgba(255,255,255,0.08);
       position: sticky; top: 0; z-index: 1000;
@@ -78,7 +62,7 @@
     .logo{ display:flex; align-items:center; gap:.55rem; }
     .logo .soap{ font-size: 2.2rem; transform: translateY(2px); }
     .logo .logo-text{
-      font-family: 'Great Vibes', cursive !important;  /* match About Us */
+      font-family: 'Great Vibes', cursive !important;
       font-size: 2.8rem; line-height: 1; letter-spacing: .4px; color:#fff;
       position:relative; display:inline-block;
       clip-path: inset(0 100% 0 0); opacity:0;
@@ -94,7 +78,6 @@
       animation: logoSweep 1.1s ease forwards .25s;
     }
 
-    /* Nav links match site look */
     .nav-links a{
       font-family: 'Bebas Neue', sans-serif;
       letter-spacing: .5px;
@@ -103,7 +86,6 @@
     }
     .nav-links a:hover{ color:#fff; }
 
-    /* ===== Booking page layout (your original UI, unchanged) ===== */
     .booking{
       max-width: 1100px; margin: 0 auto;
       padding: clamp(20px, 4vw, 48px);
@@ -126,10 +108,11 @@
       border-radius: 16px;
       box-shadow: 0 10px 30px rgba(0,0,0,0.35);
       backdrop-filter: blur(6px);
+      text-transform: lowercase;
     }
     .stepper li{
       padding: 14px 12px; text-align: center; border-radius: 12px;
-      font-weight: 600; text-transform: lowercase; color: #b6c2cf;
+      font-weight: 600; color: #b6c2cf;
       border: 1px dashed rgba(255,255,255,0.12);
       transition: transform .2s ease, background .2s ease, color .2s ease, border-color .2s ease;
     }
@@ -139,7 +122,7 @@
       background: linear-gradient(180deg, rgba(0,208,132,0.12), rgba(0,208,132,0.05));
     }
     .stepper li.active{
-      color: #111; 
+      color: #111;
       background: linear-gradient(180deg, #ffd166, #ffb703);
       border-color: rgba(255,183,3,0.65);
       transform: translateY(-1px);
@@ -147,7 +130,7 @@
 
     .booking-card{
       margin: 18px auto 0; width: min(100%, 1050px);
-      background: rgba(10, 12, 16, 0.72);     /* slightly darker card to match page darkness */
+      background: rgba(10, 12, 16, 0.72);
       border: 1px solid rgba(255,255,255,0.08);
       border-radius: 20px;
       box-shadow: 0 20px 50px rgba(0,0,0,0.45);
@@ -159,6 +142,34 @@
     fieldset{ border: none; margin: 0; padding: 0; }
     legend{ font-weight: 800; font-size: 1.2rem; margin-bottom: 14px; }
     .muted{ color: #b6c2cf; }
+
+    .booking-summary-card{
+      margin-bottom: clamp(18px, 3vw, 28px);
+      display: grid;
+      gap: 0.75rem;
+    }
+    .booking-summary-title{
+      font-family: 'Bebas Neue', sans-serif;
+      font-size: clamp(1.8rem, 3vw, 2.2rem);
+      letter-spacing: 0.16em;
+      text-transform: lowercase;
+      margin: 0;
+    }
+    .summary-note{
+      margin: 0;
+      font-size: 0.95rem;
+      color: rgba(207, 224, 238, 0.85);
+    }
+    .summary-details{
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.35rem;
+      font-size: 0.95rem;
+      color: rgba(214, 238, 255, 0.85);
+    }
+    .summary-details strong{ color: #f7fdff; font-weight: 700; }
 
     .grid-2{ display: grid; gap: 14px; grid-template-columns: 1fr; }
     .grid-2 .wide{ grid-column: 1 / -1; }
@@ -204,13 +215,6 @@
     }
     .btn:hover{ filter: brightness(1.05); }
 
-    .package-desc{
-      border: 1px dashed rgba(255,255,255,0.2);
-      border-radius: 12px;
-      padding: 12px;
-      background: rgba(255,255,255,0.03);
-    }
-
     .review{
       display:grid; gap:10px;
       border: 1px solid rgba(255,255,255,0.08);
@@ -220,10 +224,11 @@
     }
     .review dt{ font-weight: 700; color: #b6c2cf; }
     .review dd{ margin: 0 0 10px; }
+
+    .addon-empty{ color: rgba(214, 238, 255, 0.7); font-size: 0.95rem; }
   </style>
 </head>
 <body>
-  <!-- NAV -->
   <header class="navbar">
     <div class="logo">
       <span class="soap">🧼</span>
@@ -236,26 +241,256 @@
     </nav>
   </header>
 
-  <section class="booking">
+  <section class="booking" id="start">
     <h1 class="booking-title">book online</h1>
 
-    <!-- Long, centered step rectangle -->
     <div class="stepper-wrap">
       <ol class="stepper" id="stepper">
-        <li class="active">1. when &amp; where</li>
-        <li>2. how often</li>
-        <li>3. cleaning type</li>
+        <li class="active">1. price summary</li>
+        <li>2. add extras</li>
+        <li>3. when &amp; where</li>
         <li>4. your details</li>
         <li>5. review &amp; confirm</li>
       </ol>
     </div>
 
-    <!-- Application card -->
     <div class="booking-card">
       <form id="bookingForm" class="booking-form" action="https://formspree.io/f/mrblyqpr" method="POST">
-        <!-- STEP 1: When & Where -->
+        <div class="booking-summary-card">
+          <h2 class="booking-summary-title">price summary</h2>
+          <div class="quote-summary" id="booking-summary" aria-live="polite">
+            <div class="quote-summary-line">
+              <span>Base Package</span>
+              <strong id="summary-base-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-detail-row" hidden>
+              <span>Service Details</span>
+              <strong id="summary-detail-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-extras-row" hidden>
+              <span>Add-ons</span>
+              <strong id="summary-extras-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-discount-row" hidden>
+              <span>Frequency Savings</span>
+              <strong id="summary-discount-price">—</strong>
+            </div>
+            <div class="quote-summary-line total">
+              <span>Estimated Visit Total</span>
+              <strong id="summary-total-price">—</strong>
+            </div>
+          </div>
+          <p class="summary-note" id="summary-frequency-note"></p>
+          <ul class="summary-details" id="summary-detail-list"></ul>
+        </div>
+
+        <input type="hidden" name="service_key" id="input-service-key">
+        <input type="hidden" name="service_label" id="input-service-label">
+        <input type="hidden" name="square_footage_range" id="input-sqft-label">
+        <input type="hidden" name="detail_summary" id="input-detail-summary">
+        <input type="hidden" name="base_package_price" id="input-base-price">
+        <input type="hidden" name="service_detail_price" id="input-detail-price">
+        <input type="hidden" name="addons_price" id="input-addons-price">
+        <input type="hidden" name="frequency_savings" id="input-discount-price">
+        <input type="hidden" name="final_visit_total" id="input-total-price">
+        <input type="hidden" name="selected_addons" id="input-selected-addons">
+        <input type="hidden" name="origin_quote" value="index">
+        <input type="hidden" name="package" id="input-package">
+
         <fieldset class="step" data-step="1">
-          <legend>When &amp; Where</legend>
+          <legend>Your base package</legend>
+          <p class="muted">Review the base price we created from your instant quote and choose how often you'd like us to clean.</p>
+          <div class="plans">
+            <label class="plan">
+              <input type="radio" name="frequency" value="weekly" data-discount="0.25" required />
+              <div class="plan-card">
+                <div class="plan-title">Weekly</div>
+                <div class="plan-discount">25% off</div>
+                <div class="plan-note">Best value &amp; consistency</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="biweekly" data-discount="0.20" />
+              <div class="plan-card">
+                <div class="plan-title">Bi-Weekly</div>
+                <div class="plan-discount">20% off</div>
+                <div class="plan-note">Great for busy offices</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="triweekly" data-discount="0.15" />
+              <div class="plan-card">
+                <div class="plan-title">Tri-Weekly</div>
+                <div class="plan-discount">15% off</div>
+                <div class="plan-note">Light traffic spaces</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="monthly" data-discount="0.10" />
+              <div class="plan-card">
+                <div class="plan-title">Monthly</div>
+                <div class="plan-discount">10% off</div>
+                <div class="plan-note">Deep refresh once a month</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="biannual" data-discount="0.05" />
+              <div class="plan-card">
+                <div class="plan-title">Biannual</div>
+                <div class="plan-discount">5% off</div>
+                <div class="plan-note">Seasonal top-to-bottom</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="onetime" data-discount="0" />
+              <div class="plan-card">
+                <div class="plan-title">One-time</div>
+                <div class="plan-discount">Standard rate</div>
+                <div class="plan-note">Perfect for move-ins &amp; projects</div>
+              </div>
+            </label>
+          </div>
+          <div class="actions">
+            <button type="button" class="btn next">Next</button>
+          </div>
+        </fieldset>
+
+        <fieldset class="step" data-step="2" hidden>
+          <legend>Add extra services</legend>
+          <p class="muted">Add speciality tasks for this visit. Select a tile to include it and adjust the quantity if needed.</p>
+          <div class="addon-groups" id="addon-groups">
+            <div class="addon-group" data-service-group="home">
+              <p class="addon-group-title">Home &amp; Residential Extras</p>
+              <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
+                <span class="addon-icon">✨</span>
+                <span class="addon-name">Deep Clean Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
+              </div>
+              <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
+                <span class="addon-icon">🚚</span>
+                <span class="addon-name">Move In/Out Clean Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
+              </div>
+              <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
+                <span class="addon-icon">🛠️</span>
+                <span class="addon-name">Renovation Clean Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
+              </div>
+              <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
+                <span class="addon-icon">🎓</span>
+                <span class="addon-name">Move In/Out Package (Student Property)</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
+              </div>
+              <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
+                <span class="addon-icon">🏠</span>
+                <span class="addon-name">AirBnB Listing</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
+              </div>
+              <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
+                <span class="addon-icon">🐾</span>
+                <span class="addon-name">I have Pets</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
+              </div>
+              <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
+                <span class="addon-icon">🧊</span>
+                <span class="addon-name">Inside Fridge</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
+              </div>
+              <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
+                <span class="addon-icon">🔥</span>
+                <span class="addon-name">Inside Oven</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
+              </div>
+              <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
+                <span class="addon-icon">🗄️</span>
+                <span class="addon-name">Inside Cabinets</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
+              </div>
+              <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
+                <span class="addon-icon">🍽️</span>
+                <span class="addon-name">Additional Kitchen</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
+              </div>
+              <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
+                <span class="addon-icon">🪟</span>
+                <span class="addon-name">Blinds (per window)</span>
+                <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
+              </div>
+              <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
+                <span class="addon-icon">🔍</span>
+                <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
+                <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
+              </div>
+              <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
+                <span class="addon-icon">🔎</span>
+                <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
+                <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
+              </div>
+              <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
+                <span class="addon-icon">🪟</span>
+                <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
+                <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
+              </div>
+              <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
+                <span class="addon-icon">🛏️</span>
+                <span class="addon-name">Change Bed Sheets + Load Laundry</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
+              </div>
+              <div class="addon-pill color-crimson" data-addon="Load Dishwasher" data-price="10">
+                <span class="addon-icon">🍽️</span>
+                <span class="addon-name">Load Dishwasher</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
+              </div>
+              <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
+                <span class="addon-icon">🧴</span>
+                <span class="addon-name">Sanitization Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
+              </div>
+            </div>
+
+            <div class="addon-group" data-service-group="commercial,office">
+              <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
+              <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
+                <span class="addon-icon">🧼</span>
+                <span class="addon-name">Carpet Steam Cleaning Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
+              </div>
+              <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
+                <span class="addon-icon">🧽</span>
+                <span class="addon-name">Tile and Grout Cleaning Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout Cleaning quantity">
+              </div>
+              <div class="addon-pill color-mint" data-addon="Restock Bathroom Supply" data-price="40">
+                <span class="addon-icon">🧻</span>
+                <span class="addon-name">Restock Bathroom Supply</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Restock Bathroom Supply quantity">
+              </div>
+              <div class="addon-pill color-gold" data-addon="Disinfect Electronics" data-price="45">
+                <span class="addon-icon">💻</span>
+                <span class="addon-name">Disinfect Electronics</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Disinfect Electronics quantity">
+              </div>
+              <div class="addon-pill color-teal" data-addon="Empty Garbage/Recycling" data-price="18">
+                <span class="addon-icon">🗑️</span>
+                <span class="addon-name">Empty Garbage/Recycling</span>
+                <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Empty Garbage/Recycling quantity">
+              </div>
+              <div class="addon-pill color-lime" data-addon="Water Plants" data-price="15">
+                <span class="addon-icon">🌿</span>
+                <span class="addon-name">Water Plants</span>
+                <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Water Plants quantity">
+              </div>
+            </div>
+          </div>
+          <p class="addon-empty" id="addon-empty-message" hidden>No add-ons available for this service. Continue to scheduling.</p>
+          <div class="actions">
+            <button type="button" class="btn back">Back</button>
+            <button type="button" class="btn next">Next</button>
+          </div>
+        </fieldset>
+
+        <fieldset class="step" data-step="3" hidden>
+          <legend>When &amp; where</legend>
           <div class="grid-2">
             <label>
               Business name (optional)
@@ -283,66 +518,7 @@
             </label>
             <label class="wide">
               Approx. square footage
-              <input type="number" name="sqft" min="100" step="50" placeholder="e.g., 5,000" required />
-            </label>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn next">Next</button>
-          </div>
-        </fieldset>
-
-        <!-- STEP 2: How Often -->
-        <fieldset class="step" data-step="2" hidden>
-          <legend>How Often?</legend>
-          <p class="muted">Save on recurring cleanings. Choose a frequency.</p>
-          <div class="plans">
-            <label class="plan">
-              <input type="radio" name="frequency" value="weekly" required />
-              <div class="plan-card">
-                <div class="plan-title">Weekly</div>
-                <div class="plan-discount">25% off</div>
-                <div class="plan-note">Best value &amp; consistency</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="biweekly" />
-              <div class="plan-card">
-                <div class="plan-title">Bi-Weekly</div>
-                <div class="plan-discount">20% off</div>
-                <div class="plan-note">Great for busy offices</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="triweekly" />
-              <div class="plan-card">
-                <div class="plan-title">Tri-Weekly</div>
-                <div class="plan-discount">15% off</div>
-                <div class="plan-note">Light traffic spaces</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="monthly" />
-              <div class="plan-card">
-                <div class="plan-title">Monthly</div>
-                <div class="plan-discount">10% off</div>
-                <div class="plan-note">Routine upkeep</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="biannual" />
-              <div class="plan-card">
-                <div class="plan-title">Biannual</div>
-                <div class="plan-discount">5% off</div>
-                <div class="plan-note">Seasonal refresh</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="onetime" />
-              <div class="plan-card">
-                <div class="plan-title">One-time</div>
-                <div class="plan-discount">—</div>
-                <div class="plan-note">Deep clean on demand</div>
-              </div>
+              <input type="number" name="sqft" min="100" step="50" placeholder="e.g., 5,000" />
             </label>
           </div>
           <div class="actions">
@@ -351,66 +527,6 @@
           </div>
         </fieldset>
 
-        <!-- STEP 3: Cleaning Type + Packages -->
-        <fieldset class="step" data-step="3" hidden>
-          <legend>What type of cleaning?</legend>
-          <div class="grid-2">
-            <label class="wide">
-              Select a package
-              <select name="package" id="package" required>
-                <option value="" disabled selected>Choose a package…</option>
-                <option value="industrial">🏭 Industrial &amp; Warehouse Care</option>
-                <option value="office">🖥️ Office &amp; Corporate Cleaning</option>
-                <option value="specialty">🪟 Specialty Facility Services</option>
-              </select>
-            </label>
-
-            <!-- Industrial -->
-            <div class="package-desc" id="pkg-industrial" hidden>
-              <h4>🏭 Industrial &amp; Warehouse Care</h4>
-              <p class="muted"><strong>Tagline:</strong> Heavy-duty cleaning for high-demand environments.<br/><strong>Ideal for:</strong> Factories, distribution centers, and large-scale workspaces.</p>
-              <ul>
-                <li>High-dusting and overhead beam cleaning</li>
-                <li>Sweeping, scrubbing, and degreasing of production floors</li>
-                <li>Equipment and machinery wipe-downs</li>
-                <li>Loading dock and storage area cleaning</li>
-                <li>Restroom cleaning and sanitation for high-traffic use</li>
-              </ul>
-            </div>
-
-            <!-- Office -->
-            <div class="package-desc" id="pkg-office" hidden>
-              <h4>🖥️ Office &amp; Corporate Cleaning</h4>
-              <p class="muted"><strong>Tagline:</strong> A spotless, professional image for your business.<br/><strong>Ideal for:</strong> Offices, corporate headquarters, and professional buildings.</p>
-              <ul>
-                <li>Daily surface and workstation cleaning</li>
-                <li>Waste removal and recycling service</li>
-                <li>Floor care: vacuuming, mopping, and spot-cleaning carpets</li>
-                <li>Reception and common-area tidying</li>
-                <li>Restroom cleaning and supply replenishment</li>
-              </ul>
-            </div>
-
-            <!-- Specialty -->
-            <div class="package-desc" id="pkg-specialty" hidden>
-              <h4>🪟 Specialty Facility Services</h4>
-              <p class="muted"><strong>Tagline:</strong> Targeted deep-cleaning for the areas that matter most.<br/><strong>Ideal for:</strong> Businesses needing targeted or seasonal deep-cleaning.</p>
-              <ul>
-                <li>Window washing and glass polishing (interior &amp; exterior)</li>
-                <li>Cafeteria / lunchroom cleaning and sanitization</li>
-                <li>Washroom deep-clean and disinfection</li>
-                <li>Touchpoint sanitization (doors, handles, switches)</li>
-                <li>Post-construction or move-out cleaning</li>
-              </ul>
-            </div>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn back">Back</button>
-            <button type="button" class="btn next">Next</button>
-          </div>
-        </fieldset>
-
-        <!-- STEP 4: Contact -->
         <fieldset class="step" data-step="4" hidden>
           <legend>Your contact information</legend>
           <div class="grid-2">
@@ -437,12 +553,9 @@
           </div>
         </fieldset>
 
-        <!-- STEP 5: Review & Confirm -->
         <fieldset class="step" data-step="5" hidden>
-          <legend>Review &amp; Confirm</legend>
-          <dl class="review" id="reviewList">
-            <!-- Filled by JS -->
-          </dl>
+          <legend>Review &amp; confirm</legend>
+          <dl class="review" id="reviewList"></dl>
           <div class="actions">
             <button type="button" class="btn back">Back</button>
             <button type="submit" class="btn submit">Submit</button>
@@ -458,7 +571,6 @@
     </div>
   </section>
 
-  <!-- iOS detector -->
   <script>
     (function () {
       var iOS = /iP(hone|od|ad)/.test(navigator.platform) || (navigator.userAgent.includes('Mac') && navigator.maxTouchPoints > 1);
@@ -466,62 +578,291 @@
     })();
   </script>
 
-  <!-- Booking wizard JS (unchanged, just scoped to this page) -->
   <script>
     (function(){
       const form = document.getElementById('bookingForm');
-      const steps = Array.from(document.querySelectorAll('.step'));
-      const stepper = document.getElementById('stepper').children;
-      const reviewList = document.getElementById('reviewList');
-      let current = 0;
+      if(!form) return;
 
+      const steps = Array.from(form.querySelectorAll('.step'));
+      const stepper = Array.from(document.getElementById('stepper').children || []);
+      const reviewList = document.getElementById('reviewList');
+      const successEl = document.getElementById('bookingSuccess');
+
+      const summaryBaseEl = document.getElementById('summary-base-price');
+      const summaryDetailEl = document.getElementById('summary-detail-price');
+      const summaryDetailRow = document.getElementById('summary-detail-row');
+      const summaryExtrasEl = document.getElementById('summary-extras-price');
+      const summaryExtrasRow = document.getElementById('summary-extras-row');
+      const summaryDiscountEl = document.getElementById('summary-discount-price');
+      const summaryDiscountRow = document.getElementById('summary-discount-row');
+      const summaryTotalEl = document.getElementById('summary-total-price');
+      const summaryNoteEl = document.getElementById('summary-frequency-note');
+      const summaryDetailList = document.getElementById('summary-detail-list');
+      const addonEmptyMessage = document.getElementById('addon-empty-message');
+
+      const hiddenServiceKey = document.getElementById('input-service-key');
+      const hiddenServiceLabel = document.getElementById('input-service-label');
+      const hiddenSqftLabel = document.getElementById('input-sqft-label');
+      const hiddenDetailSummary = document.getElementById('input-detail-summary');
+      const hiddenBasePrice = document.getElementById('input-base-price');
+      const hiddenDetailPrice = document.getElementById('input-detail-price');
+      const hiddenAddonsPrice = document.getElementById('input-addons-price');
+      const hiddenDiscountPrice = document.getElementById('input-discount-price');
+      const hiddenTotalPrice = document.getElementById('input-total-price');
+      const hiddenSelectedAddons = document.getElementById('input-selected-addons');
+      const hiddenPackage = document.getElementById('input-package');
+
+      const frequencyInputs = Array.from(form.querySelectorAll('input[name="frequency"]'));
+      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
+      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+
+      const params = new URLSearchParams(window.location.search);
+      const serviceKey = params.get('service') || '';
+      const serviceLabel = params.get('serviceLabel') || '';
+      const sqftKey = params.get('sqft') || '';
+      const sqftLabel = params.get('sqftLabel') || '';
+      const basePrice = Number(params.get('basePrice') || params.get('total') || 0);
+      const detailPrice = Number(params.get('detailPrice') || 0);
+      const totalBase = basePrice + detailPrice;
+
+      const detailSelections = [];
+      function pushDetail(label, value){
+        if(value){ detailSelections.push(label + ': ' + value); }
+      }
+      pushDetail('Service', serviceLabel);
+      pushDetail('Square Footage', sqftLabel);
+      pushDetail('Rooms', params.get('homeRoomsLabel'));
+      pushDetail('Bathrooms', params.get('homeBathroomsLabel'));
+      pushDetail('Pets', params.get('homePetsLabel'));
+      pushDetail('Offices', params.get('officeOfficesLabel'));
+      pushDetail('Office Bathrooms', params.get('officeBathroomsLabel'));
+
+      hiddenServiceKey.value = serviceKey;
+      hiddenServiceLabel.value = serviceLabel;
+      hiddenSqftLabel.value = sqftLabel;
+      hiddenDetailSummary.value = detailSelections.join(' | ');
+      hiddenBasePrice.value = basePrice.toFixed(2);
+      hiddenDetailPrice.value = detailPrice.toFixed(2);
+      hiddenPackage.value = serviceLabel || serviceKey;
+
+      const sqftInput = form.querySelector('input[name="sqft"]');
+      if(sqftInput && sqftKey){
+        const avg = (() => {
+          if(sqftKey.includes('-')){
+            const parts = sqftKey.split('-').map(p => parseInt(p, 10));
+            if(parts.length === 2 && parts.every(n => !Number.isNaN(n))){
+              return Math.round((parts[0] + parts[1]) / 2);
+            }
+          }
+          return '';
+        })();
+        if(avg) sqftInput.value = avg;
+      }
+
+      const nameField = form.querySelector('input[name="name"]');
+      const emailField = form.querySelector('input[name="email"]');
+      const quoteName = params.get('firstName');
+      const quoteEmail = params.get('email');
+      if(nameField && quoteName) nameField.value = quoteName.trim();
+      if(emailField && quoteEmail) emailField.value = quoteEmail.trim();
+
+      function formatCurrency(value){
+        if(!value) return '—';
+        return `$${Math.round(value).toString()}`;
+      }
+
+      function updateDetailList(){
+        summaryDetailList.innerHTML = '';
+        detailSelections.forEach(item => {
+          const [label, val] = item.split(':');
+          const li = document.createElement('li');
+          li.innerHTML = `<strong>${label.trim()}:</strong> ${val ? val.trim() : ''}`;
+          summaryDetailList.appendChild(li);
+        });
+      }
+      updateDetailList();
+
+      function updateAddonVisibility(){
+        let visibleGroups = 0;
+        addonGroups.forEach(group => {
+          const services = (group.dataset.serviceGroup || '').split(',');
+          const active = serviceKey && services.includes(serviceKey);
+          group.classList.toggle('active', active);
+          if(active) visibleGroups += 1;
+        });
+        if(addonEmptyMessage){ addonEmptyMessage.hidden = visibleGroups !== 0; }
+      }
+      updateAddonVisibility();
+
+      const extrasState = [];
+      function computeExtras(){
+        extrasState.length = 0;
+        addonPills.forEach(pill => {
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+          if(!pill.classList.contains('active')) return;
+          const qtyInput = pill.querySelector('.addon-qty');
+          const qty = qtyInput ? Math.max(Number(qtyInput.value) || 1, Number(qtyInput.min) || 1) : 1;
+          const price = Number(pill.dataset.price || 0);
+          const name = pill.querySelector('.addon-name')?.textContent.trim() || pill.dataset.addon || 'Addon';
+          extrasState.push({ name, qty, price });
+        });
+        return extrasState;
+      }
+
+      function buildExtrasLabel(){
+        if(!extrasState.length) return '';
+        return extrasState.map(item => `${item.name} ×${item.qty}`).join(', ');
+      }
+
+      function selectedFrequency(){
+        return frequencyInputs.find(input => input.checked) || null;
+      }
+
+      function updateSummary(){
+        const extras = computeExtras();
+        const extrasTotal = extras.reduce((sum, item) => sum + item.price * item.qty, 0);
+        const freqInput = selectedFrequency();
+        const discountRate = freqInput ? Number(freqInput.dataset.discount || 0) : 0;
+        const subtotal = totalBase + extrasTotal;
+        const discount = subtotal * discountRate;
+        const finalTotal = subtotal - discount;
+
+        summaryBaseEl.textContent = formatCurrency(basePrice);
+
+        if(detailPrice > 0){
+          summaryDetailRow.hidden = false;
+          summaryDetailEl.textContent = `+$${Math.round(detailPrice)}`;
+        } else {
+          summaryDetailRow.hidden = true;
+          summaryDetailEl.textContent = '—';
+        }
+
+        if(extrasTotal > 0){
+          summaryExtrasRow.hidden = false;
+          summaryExtrasEl.textContent = `+$${Math.round(extrasTotal)}`;
+        } else {
+          summaryExtrasRow.hidden = true;
+          summaryExtrasEl.textContent = '—';
+        }
+
+        if(discount > 0){
+          summaryDiscountRow.hidden = false;
+          summaryDiscountEl.textContent = `−$${Math.round(discount)}`;
+        } else {
+          summaryDiscountRow.hidden = true;
+          summaryDiscountEl.textContent = '—';
+        }
+
+        summaryTotalEl.textContent = finalTotal ? formatCurrency(finalTotal) : '—';
+
+        if(summaryNoteEl){
+          if(totalBase <= 0){
+            summaryNoteEl.textContent = 'Start with an instant quote to unlock pricing.';
+          } else if(freqInput){
+            const freqLabelMap = {
+              weekly: 'Weekly (25% off)',
+              biweekly: 'Bi-Weekly (20% off)',
+              triweekly: 'Tri-Weekly (15% off)',
+              monthly: 'Monthly (10% off)',
+              biannual: 'Biannual (5% off)',
+              onetime: 'One-time'
+            };
+            summaryNoteEl.textContent = `Includes ${freqLabelMap[freqInput.value] || 'your chosen frequency'} pricing.`;
+          } else {
+            summaryNoteEl.textContent = 'Choose a frequency to see recurring savings.';
+          }
+        }
+
+        hiddenAddonsPrice.value = extrasTotal.toFixed(2);
+        hiddenDiscountPrice.value = discount.toFixed(2);
+        hiddenTotalPrice.value = finalTotal.toFixed(2);
+        hiddenSelectedAddons.value = buildExtrasLabel();
+      }
+
+      addonPills.forEach(pill => {
+        const qtyInput = pill.querySelector('.addon-qty');
+        if(qtyInput){
+          qtyInput.disabled = true;
+        }
+
+        pill.addEventListener('click', (event) => {
+          if(event.target === qtyInput) return;
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+
+          pill.classList.toggle('active');
+          const active = pill.classList.contains('active');
+          pill.setAttribute('aria-pressed', active ? 'true' : 'false');
+          if(qtyInput){
+            qtyInput.disabled = !active;
+            if(active && (!qtyInput.value || Number(qtyInput.value) < Number(qtyInput.min || 1))){
+              qtyInput.value = qtyInput.min || 1;
+            }
+          }
+          updateSummary();
+        });
+
+        pill.addEventListener('keydown', evt => {
+          if(evt.key === 'Enter' || evt.key === ' '){
+            evt.preventDefault();
+            pill.click();
+          }
+        });
+
+        pill.setAttribute('tabindex', '0');
+        pill.setAttribute('role', 'button');
+        pill.setAttribute('aria-pressed', 'false');
+
+        if(qtyInput){
+          qtyInput.addEventListener('input', () => {
+            if(!pill.classList.contains('active')) return;
+            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min || 1)){
+              qtyInput.value = qtyInput.min || 1;
+            }
+            updateSummary();
+          });
+        }
+      });
+
+      frequencyInputs.forEach(input => {
+        input.addEventListener('change', updateSummary);
+      });
+
+      let current = 0;
       function showStep(i){
-        steps.forEach((s, idx)=>{ s.hidden = idx !== i; });
-        Array.from(stepper).forEach((li, idx)=>{
-          li.classList.toggle('active', idx === i);
-          li.classList.toggle('done', idx < i);
+        steps.forEach((step, idx) => { step.hidden = idx !== i; });
+        stepper.forEach((item, idx) => {
+          item.classList.toggle('active', idx === i);
+          item.classList.toggle('done', idx < i);
         });
         current = i;
-        if (i === 4) buildReview(); // step index 4 = "Step 5"
         window.scrollTo({ top: 0, behavior: 'smooth' });
+        if(i === steps.length - 1){
+          buildReview();
+        }
       }
 
-      document.addEventListener('click', (e)=>{
-        if(e.target.matches('.next')){
-          const vis = steps[current];
-          const req = vis.querySelectorAll('[required]');
-          for (const el of req){ if(!el.value){ el.focus(); return; } }
-          showStep(Math.min(current+1, steps.length-1));
+      document.addEventListener('click', (event) => {
+        if(event.target.matches('.next')){
+          const visible = steps[current];
+          const required = Array.from(visible.querySelectorAll('[required]'));
+          for(const field of required){
+            if(!field.value){
+              field.focus();
+              if(field.reportValidity){ field.reportValidity(); }
+              return;
+            }
+          }
+          showStep(Math.min(current + 1, steps.length - 1));
         }
-        if(e.target.matches('.back')){
-          showStep(Math.max(current-1, 0));
+        if(event.target.matches('.back')){
+          showStep(Math.max(current - 1, 0));
         }
       });
 
-      form.addEventListener('submit', (e)=>{
-        e.preventDefault();
-        // Let Formspree submit normally:
-        form.submit();
-        // If you prefer the inline success card instead, uncomment below:
-        // form.hidden = true;
-        // document.getElementById('bookingSuccess').hidden = false;
-      });
-
-      // package descriptions toggle
-      const pkg = document.getElementById('package');
-      function updatePkg(){
-        const blocks = {
-          industrial: document.getElementById('pkg-industrial'),
-          office: document.getElementById('pkg-office'),
-          specialty: document.getElementById('pkg-specialty')
-        };
-        Object.values(blocks).forEach(b=> b.hidden = true);
-        if (blocks[pkg.value]) blocks[pkg.value].hidden = false;
-      }
-      if(pkg){ pkg.addEventListener('change', updatePkg); }
-
-      // Build the review summary
       function buildReview(){
+        if(!reviewList) return;
         const fd = new FormData(form);
         const freqMap = {
           weekly: 'Weekly (25% off)',
@@ -531,215 +872,99 @@
           biannual: 'Biannual (5% off)',
           onetime: 'One-time'
         };
-        const pkgMap = {
-          industrial: '🏭 Industrial & Warehouse Care',
-          office: '🖥️ Office & Corporate Cleaning',
-          specialty: '🪟 Specialty Facility Services'
-        };
 
         const rows = [
+          ['Service', hiddenServiceLabel.value || '—'],
+          ['Square Footage', hiddenSqftLabel.value || fd.get('sqft') || '—'],
+          ['Details', hiddenDetailSummary.value || '—'],
+          ['Frequency', freqMap[fd.get('frequency')] || '—'],
+          ['Add-ons', hiddenSelectedAddons.value || 'None'],
+          ['Base Package', hiddenBasePrice.value ? `$${Math.round(Number(hiddenBasePrice.value))}` : '—'],
+          ['Service Details', hiddenDetailPrice.value ? `$${Math.round(Number(hiddenDetailPrice.value))}` : '—'],
+          ['Add-on Total', hiddenAddonsPrice.value ? `$${Math.round(Number(hiddenAddonsPrice.value))}` : '—'],
+          ['Frequency Savings', hiddenDiscountPrice.value && Number(hiddenDiscountPrice.value) ? `-$${Math.round(Number(hiddenDiscountPrice.value))}` : '—'],
+          ['Estimated Visit Total', hiddenTotalPrice.value && Number(hiddenTotalPrice.value) ? `$${Math.round(Number(hiddenTotalPrice.value))}` : '—'],
           ['Business', fd.get('business') || '—'],
           ['Address', [fd.get('address'), fd.get('city'), fd.get('postal')].filter(Boolean).join(', ') || '—'],
           ['Preferred Date', fd.get('date') || '—'],
           ['Preferred Time', fd.get('time') || '—'],
-          ['Approx. Sq Ft', fd.get('sqft') || '—'],
-          ['Frequency', freqMap[fd.get('frequency')] || '—'],
-          ['Package', pkgMap[fd.get('package')] || '—'],
           ['Full Name', fd.get('name') || '—'],
           ['Email', fd.get('email') || '—'],
           ['Phone', fd.get('phone') || '—'],
-          ['Notes', (fd.get('notes') || '—')]
+          ['Notes', fd.get('notes') || '—']
         ];
 
-        reviewList.innerHTML = rows.map(([k,v])=> `<dt>${k}</dt><dd>${String(v).replace(/</g,'&lt;')}</dd>`).join('');
+        reviewList.innerHTML = rows.map(([label, value]) => `<dt>${label}</dt><dd>${String(value)}</dd>`).join('');
       }
 
-      // init
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const submitBtn = form.querySelector('.submit');
+        const allButtons = form.querySelectorAll('button');
+        allButtons.forEach(btn => btn.disabled = true);
+        if(submitBtn) submitBtn.textContent = 'Sending…';
+
+        const fd = new FormData(form);
+        if(!fd.get('_subject')){
+          fd.append('_subject', 'New Booking Request — Dufferin Deep Clean');
+        }
+
+        const freqMapShort = {
+          weekly: 'Weekly (25%)',
+          biweekly: 'Bi-Weekly (20%)',
+          triweekly: 'Tri-Weekly (15%)',
+          monthly: 'Monthly (10%)',
+          biannual: 'Biannual (5%)',
+          onetime: 'One-time'
+        };
+
+        const pricingSummary = [
+          `Service: ${hiddenServiceLabel.value || serviceKey || '—'}`,
+          `Square Footage: ${hiddenSqftLabel.value || fd.get('sqft') || '—'}`,
+          `Details: ${hiddenDetailSummary.value || '—'}`,
+          `Frequency: ${freqMapShort[fd.get('frequency')] || '—'}`,
+          `Base Package: ${hiddenBasePrice.value ? `$${Math.round(Number(hiddenBasePrice.value))}` : '—'}`,
+          `Service Details: ${hiddenDetailPrice.value ? `$${Math.round(Number(hiddenDetailPrice.value))}` : '—'}`,
+          `Add-ons: ${hiddenSelectedAddons.value || 'None'}`,
+          `Add-on Total: ${hiddenAddonsPrice.value ? `$${Math.round(Number(hiddenAddonsPrice.value))}` : '—'}`,
+          `Frequency Savings: ${hiddenDiscountPrice.value && Number(hiddenDiscountPrice.value) ? `-$${Math.round(Number(hiddenDiscountPrice.value))}` : '—'}`,
+          `Estimated Visit Total: ${hiddenTotalPrice.value && Number(hiddenTotalPrice.value) ? `$${Math.round(Number(hiddenTotalPrice.value))}` : '—'}`
+        ].join('\n');
+
+        fd.append('pricing_summary', pricingSummary);
+
+        try {
+          const res = await fetch(form.action, {
+            method: 'POST',
+            body: fd,
+            headers: { Accept: 'application/json' }
+          });
+
+          if(res.ok){
+            form.hidden = true;
+            if(successEl) successEl.hidden = false;
+          } else {
+            let message = 'There was a problem sending your booking request. Please try again.';
+            try {
+              const data = await res.json();
+              if(data && data.errors && data.errors.length){
+                message = data.errors.map(err => err.message).join('\n');
+              }
+            } catch(_){}
+            alert(message);
+          }
+        } catch(err){
+          alert('Network error. Please check your connection and try again.');
+        } finally {
+          allButtons.forEach(btn => btn.disabled = false);
+          if(submitBtn) submitBtn.textContent = 'Submit';
+        }
+      });
+
+      updateSummary();
       showStep(0);
     })();
   </script>
-
-  <!-- OPTIONAL: Google Places Autocomplete (shows "Powered by Google" automatically)
-       Replace YOUR_API_KEY_HERE with your Maps JavaScript API key with Places enabled.
-       If you skip this, the form still works—this block is optional. -->
-  <script>
-    (function attachPlaces(){
-      window.initPlaces = function(){
-        if (!window.google || !google.maps || !google.maps.places) return;
-        const addr = document.getElementById('address');
-        if (!addr) return;
-        const ac = new google.maps.places.Autocomplete(addr, {
-          types: ['address'],
-          fields: ['address_components','formatted_address']
-        });
-        ac.addListener('place_changed', () => {
-          const p = ac.getPlace();
-          if (!p || !p.address_components) return;
-          const cityEl = document.getElementById('city');
-          const postalEl = document.getElementById('postal');
-          const comps = p.address_components;
-
-          const get = (type) => (comps.find(c => c.types.includes(type)) || {}).long_name || '';
-          const city = get('locality') || get('postal_town') || get('administrative_area_level_3') || '';
-          const postal = get('postal_code') || '';
-
-          if (city && cityEl) cityEl.value = city;
-          if (postal && postalEl) postalEl.value = postal;
-        });
-      };
-
-      // If developer adds the script later, this still works.
-      // (Do nothing if script isn't present yet.)
-    })();
-  </script>
-  <!-- If you want Places now, uncomment the next line and insert your key:
-  <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY_HERE&libraries=places&callback=initPlaces" async defer></script>
-  -->
 </body>
 </html>
-<!-- BOOKING FORM -->
-<form id="bookingForm"
-      action="https://formspree.io/f/mrblyqpr"
-      method="POST"
-      novalidate>
-
-  <!-- hidden meta sent to Formspree -->
-  <input type="hidden" name="_subject" value="New Booking — DufferinDeepClean">
-  <!-- optional: redirect after success (change URL if you have a thank-you page) -->
-  <input type="hidden" name="_redirect" value="https://dufferindeepclean.ca/thank-you.html">
-  <input type="hidden" name="page" value="book.html">
-
-  <!-- STEP 1 — when & where -->
-  <section class="step" data-step="1">
-    <input name="date" type="date" required>
-    <input name="time" type="time" required>
-    <input name="address" type="text" placeholder="Street address" required>
-    <button type="button" class="next">Next</button>
-  </section>
-
-  <!-- STEP 2 — how often -->
-  <section class="step" data-step="2" hidden>
-    <select name="frequency" required>
-      <option value="">Select frequency</option>
-      <option>One-time</option>
-      <option>Weekly (25% off)</option>
-      <option>Bi-Weekly (20% off)</option>
-      <option>Monthly (10% off)</option>
-      <option>Biannual</option>
-    </select>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 3 — cleaning type -->
-  <section class="step" data-step="3" hidden>
-    <select name="package" required>
-      <option value="">Select a package</option>
-      <option>Specialty Facility Services</option>
-      <option>Office Basic</option>
-      <option>Deep Clean</option>
-    </select>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 4 — your details -->
-  <section class="step" data-step="4" hidden>
-    <input name="full_name" type="text" placeholder="Full name" required>
-    <input name="email" type="email" placeholder="Email" required>
-    <input name="phone" type="tel" placeholder="Phone" required>
-    <textarea name="notes" placeholder="Anything we should know?"></textarea>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 5 — review & confirm -->
-  <section class="step" data-step="5" hidden>
-    <!-- Optional: render a summary here -->
-    <label class="agree">
-      <input type="checkbox" name="agree" required>
-      I agree to the terms and confirm the details are correct.
-    </label>
-
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <!-- IMPORTANT: this must be type="submit" -->
-      <button type="submit" id="submitBtn">Submit</button>
-    </div>
-  </section>
-
-  <!-- inline status messages -->
-  <p id="formStatus" role="status" aria-live="polite" style="display:none;"></p>
-</form>
-
-<script>
-(function() {
-  const steps = [...document.querySelectorAll('.step')];
-  let i = 0;
-  const show = (n) => {
-    steps.forEach((s, idx) => s.hidden = idx !== n);
-    i = n;
-  };
-
-  document.addEventListener('click', (e) => {
-    if (e.target.classList.contains('next')) {
-      const current = steps[i];
-      // simple validation: ensure current step's required inputs are filled
-      const required = current.querySelectorAll('[required]');
-      for (const field of required) {
-        if (!field.checkValidity()) { field.reportValidity(); return; }
-      }
-      show(Math.min(i + 1, steps.length - 1));
-    }
-    if (e.target.classList.contains('back')) show(Math.max(i - 1, 0));
-  });
-
-  // Ajax submit so you can stay on the page and show a message
-  const form = document.getElementById('bookingForm');
-  const status = document.getElementById('formStatus');
-
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault(); // prevent page reload
-
-    // Final validation across the whole form
-    if (!form.checkValidity()) {
-      // report the first invalid input
-      const firstInvalid = form.querySelector(':invalid');
-      if (firstInvalid) firstInvalid.reportValidity();
-      return;
-    }
-
-    const data = new FormData(form);
-    try {
-      const resp = await fetch(form.action, {
-        method: 'POST',
-        body: data,
-        headers: { 'Accept': 'application/json' }
-      });
-
-      if (resp.ok) {
-        status.style.display = 'block';
-        status.textContent = 'Thanks! Your booking request was sent. We’ll email you shortly.';
-        form.reset();
-        show(0); // go back to step 1
-      } else {
-        const err = await resp.json().catch(() => ({}));
-        throw new Error(err.errors?.map(e => e.message).join(', ') || 'Submission failed.');
-      }
-    } catch (err) {
-      status.style.display = 'block';
-      status.textContent = 'Sorry, we could not submit the form. Please try again or email us.';
-      console.error(err);
-    }
-  });
-
-  // start on step 1
-  show(0);
-})();
-</script>

--- a/index.html
+++ b/index.html
@@ -170,11 +170,6 @@
   <!-- HERO -->
   <section id="home" class="split-screen">
     <div class="text-side">
-      <h1 class="headline">
-        <span>We</span> <span>Scrub</span> <span>You</span> <span>Shine</span>
-        <img src="cleanerguy.png" alt="Cleaner" class="headline-image" />
-      </h1>
-
       <div class="rotator-card" id="service-rotator">
         <div class="rotator-window" aria-live="polite">
           <div class="rotator-line active" data-title="Residential Homes">
@@ -243,142 +238,82 @@
 
             <div class="quote-summary" aria-live="polite">
               <div class="quote-summary-line">
-                <span>Base Estimate</span>
+                <span>Base Package</span>
                 <strong id="quote-base-price">—</strong>
               </div>
+              <div class="quote-summary-line" id="quote-detail-row" hidden>
+                <span>Service Details</span>
+                <strong id="quote-detail-price">—</strong>
+              </div>
               <div class="quote-summary-line total">
-                <span>Total with Customizations</span>
+                <span>Estimated Visit Total</span>
                 <strong id="quote-total-price">—</strong>
               </div>
             </div>
 
-            <div id="quote-customize" class="quote-customize" aria-hidden="true">
-              <div class="customize-heading" role="status">Customize your cleaning</div>
-
-              <div class="addon-groups">
-                <div class="addon-group" data-service-group="home">
-                  <p class="addon-group-title">Home &amp; Residential Extras</p>
-                  <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
-                    <span class="addon-icon">✨</span>
-                    <span class="addon-name">Deep Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
-                    <span class="addon-icon">🚚</span>
-                    <span class="addon-name">Move In/Out Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
-                    <span class="addon-icon">🛠️</span>
-                    <span class="addon-name">Renovation Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
-                    <span class="addon-icon">🎓</span>
-                    <span class="addon-name">Move In/Out Package (Student Property)</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
-                  </div>
-                  <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
-                    <span class="addon-icon">🏠</span>
-                    <span class="addon-name">AirBnB Listing</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
-                  </div>
-                  <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
-                    <span class="addon-icon">🐾</span>
-                    <span class="addon-name">I have Pets</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
-                  </div>
-                  <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
-                    <span class="addon-icon">🧊</span>
-                    <span class="addon-name">Inside Fridge</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
-                  </div>
-                  <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
-                    <span class="addon-icon">🔥</span>
-                    <span class="addon-name">Inside Oven</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
-                  </div>
-                  <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
-                    <span class="addon-icon">🗄️</span>
-                    <span class="addon-name">Inside Cabinets</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
-                  </div>
-                  <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
-                    <span class="addon-icon">🍽️</span>
-                    <span class="addon-name">Additional Kitchen</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
-                  </div>
-                  <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
-                    <span class="addon-icon">🪟</span>
-                    <span class="addon-name">Blinds (per window)</span>
-                    <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
-                  </div>
-                  <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
-                    <span class="addon-icon">🔍</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
-                  </div>
-                  <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
-                    <span class="addon-icon">🔎</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
-                  </div>
-                  <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
-                    <span class="addon-icon">🪟</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
-                  </div>
-                  <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
-                    <span class="addon-icon">🛏️</span>
-                    <span class="addon-name">Change Bed Sheets + Load Laundry</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
-                  </div>
-                  <div class="addon-pill color-crimson" data-addon="Load dishwasher" data-price="10">
-                    <span class="addon-icon">🍽️</span>
-                    <span class="addon-name">Load Dishwasher</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
-                  </div>
-                  <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
-                    <span class="addon-icon">🧴</span>
-                    <span class="addon-name">Sanitization Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
-                  </div>
-                </div>
-
-                <div class="addon-group" data-service-group="commercial,office">
-                  <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
-                  <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
-                    <span class="addon-icon">🧼</span>
-                    <span class="addon-name">Carpet Steam Cleaning Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
-                  </div>
-                  <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
-                    <span class="addon-icon">🧽</span>
-                    <span class="addon-name">Tile and Grout Cleaning Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout Cleaning quantity">
-                  </div>
-                  <div class="addon-pill color-mint" data-addon="Restock Bathroom Supply" data-price="40">
-                    <span class="addon-icon">🧻</span>
-                    <span class="addon-name">Restock Bathroom Supply</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Restock Bathroom Supply quantity">
-                  </div>
-                  <div class="addon-pill color-gold" data-addon="Disinfect Electronics" data-price="45">
-                    <span class="addon-icon">💻</span>
-                    <span class="addon-name">Disinfect Electronics</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Disinfect Electronics quantity">
-                  </div>
-                  <div class="addon-pill color-teal" data-addon="Empty Garbage/Recycling" data-price="18">
-                    <span class="addon-icon">🗑️</span>
-                    <span class="addon-name">Empty Garbage/Recycling</span>
-                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Empty Garbage/Recycling quantity">
-                  </div>
-                  <div class="addon-pill color-lime" data-addon="Water Plants" data-price="15">
-                    <span class="addon-icon">🌿</span>
-                    <span class="addon-name">Water Plants</span>
-                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Water Plants quantity">
+            <div id="service-details" class="service-details" aria-live="polite">
+              <div class="service-detail-group" data-service-detail="home" aria-hidden="true">
+                <p class="service-detail-title">Home Cleaning Details</p>
+                <div class="service-detail-grid">
+                  <label class="field" for="home-rooms">
+                    <span class="field-label">Number of Rooms</span>
+                    <select id="home-rooms" name="home-rooms" data-required data-service-required="home">
+                      <option value="" disabled selected>Select rooms</option>
+                      <option value="1-2">1 – 2 rooms</option>
+                      <option value="3-4">3 – 4 rooms</option>
+                      <option value="5-6">5 – 6 rooms</option>
+                      <option value="7+">7+ rooms</option>
+                    </select>
+                  </label>
+                  <label class="field" for="home-bathrooms">
+                    <span class="field-label">Number of Bathrooms</span>
+                    <select id="home-bathrooms" name="home-bathrooms" data-required data-service-required="home">
+                      <option value="" disabled selected>Select bathrooms</option>
+                      <option value="1">1 bathroom</option>
+                      <option value="2">2 bathrooms</option>
+                      <option value="3">3 bathrooms</option>
+                      <option value="4+">4+ bathrooms</option>
+                    </select>
+                  </label>
+                  <div class="field field-choice">
+                    <span class="field-label">Are there pets?</span>
+                    <div class="choice-buttons" role="group" aria-label="Are there pets?">
+                      <button type="button" class="choice-button" data-value="no" data-target="home-pets">No</button>
+                      <button type="button" class="choice-button" data-value="yes" data-target="home-pets">Yes</button>
+                    </div>
+                    <input type="hidden" id="home-pets" name="home-pets" data-required data-service-required="home">
                   </div>
                 </div>
               </div>
+
+              <div class="service-detail-group" data-service-detail="office" aria-hidden="true">
+                <p class="service-detail-title">Office Workspace Details</p>
+                <div class="service-detail-grid">
+                  <label class="field" for="office-offices">
+                    <span class="field-label">Number of Offices</span>
+                    <select id="office-offices" name="office-offices" data-required data-service-required="office">
+                      <option value="" disabled selected>Select offices</option>
+                      <option value="1-5">1 – 5 offices</option>
+                      <option value="6-10">6 – 10 offices</option>
+                      <option value="11-20">11 – 20 offices</option>
+                      <option value="21+">21+ offices</option>
+                    </select>
+                  </label>
+                  <label class="field" for="office-bathrooms">
+                    <span class="field-label">Number of Bathrooms</span>
+                    <select id="office-bathrooms" name="office-bathrooms" data-required data-service-required="office">
+                      <option value="" disabled selected>Select bathrooms</option>
+                      <option value="1-2">1 – 2 bathrooms</option>
+                      <option value="3-4">3 – 4 bathrooms</option>
+                      <option value="5+">5+ bathrooms</option>
+                    </select>
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div class="quote-actions">
+              <button type="button" id="quote-see-price" class="quote-see-price" disabled>See My Price</button>
             </div>
           </form>
         </div>
@@ -472,11 +407,14 @@
       const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
       const basePriceEl = document.getElementById('quote-base-price');
       const totalPriceEl = document.getElementById('quote-total-price');
-      const customizeBlock = document.getElementById('quote-customize');
       const serviceSelect = document.getElementById('quote-service');
       const sqftSelect = document.getElementById('quote-square-footage');
-      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
-      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+      const serviceDetailsWrapper = document.getElementById('service-details');
+      const detailGroups = serviceDetailsWrapper ? Array.from(serviceDetailsWrapper.querySelectorAll('[data-service-detail]')) : [];
+      const detailSummaryRow = document.getElementById('quote-detail-row');
+      const detailSummaryEl = document.getElementById('quote-detail-price');
+      const choiceButtons = Array.from(form.querySelectorAll('.choice-button'));
+      const seePriceBtn = document.getElementById('quote-see-price');
 
       const basePricing = {
         home: {
@@ -505,146 +443,274 @@
         }
       };
 
+      const detailPricing = {
+        home: {
+          rooms: {
+            '1-2': 0,
+            '3-4': 25,
+            '5-6': 55,
+            '7+': 85
+          },
+          bathrooms: {
+            '1': 0,
+            '2': 18,
+            '3': 36,
+            '4+': 54
+          },
+          pets: {
+            no: 0,
+            yes: 25
+          }
+        },
+        office: {
+          offices: {
+            '1-5': 0,
+            '6-10': 45,
+            '11-20': 90,
+            '21+': 135
+          },
+          bathrooms: {
+            '1-2': 0,
+            '3-4': 40,
+            '5+': 70
+          }
+        }
+      };
+
+      function fieldIsRelevant(field){
+        const serviceRequirement = field.dataset.serviceRequired;
+        if(!serviceRequirement) return true;
+        const serviceKey = serviceSelect.value;
+        if(!serviceKey) return false;
+        return serviceRequirement.split(',').includes(serviceKey);
+      }
+
       function hasAllRequired(){
         return requiredFields.every(field => {
+          if(!fieldIsRelevant(field)) return true;
           if(field.type === 'email'){
             return field.value.trim() !== '' && field.value.includes('@');
+          }
+          if(field.tagName === 'SELECT'){
+            return field.value.trim() !== '';
           }
           return field.value.trim() !== '';
         });
       }
 
-      function resetAddons(){
-        addonPills.forEach(pill => {
-          pill.classList.remove('active');
-          const qty = pill.querySelector('.addon-qty');
-          if(qty){
-            qty.value = 1;
-            qty.disabled = true;
+      function resetServiceGroup(group){
+        const inputs = Array.from(group.querySelectorAll('[data-service-required]'));
+        inputs.forEach(input => {
+          if(input.tagName === 'SELECT'){
+            input.selectedIndex = 0;
+          } else {
+            input.value = '';
           }
-          pill.setAttribute('aria-pressed', 'false');
+        });
+
+        const buttons = Array.from(group.querySelectorAll('.choice-button'));
+        buttons.forEach(btn => {
+          btn.classList.remove('active');
+          btn.setAttribute('aria-pressed', 'false');
         });
       }
 
-      function updateAddonAvailability(serviceKey){
-        addonGroups.forEach(group => {
-          const services = group.dataset.serviceGroup.split(',');
-          const match = services.includes(serviceKey);
-          group.classList.toggle('active', match);
-        });
-
-        addonPills.forEach(pill => {
-          const parent = pill.closest('.addon-group');
-          const enabled = parent && parent.classList.contains('active');
-          pill.style.display = enabled ? '' : 'none';
-          if(!enabled){
-            pill.classList.remove('active');
-            const qty = pill.querySelector('.addon-qty');
-            if(qty){
-              qty.value = 1;
-              qty.disabled = true;
-            }
-            pill.setAttribute('aria-pressed', 'false');
+      function updateServiceDetails(serviceKey){
+        if(!serviceDetailsWrapper) return;
+        let activeCount = 0;
+        detailGroups.forEach(group => {
+          const services = group.dataset.serviceDetail.split(',');
+          const match = serviceKey && services.includes(serviceKey);
+          group.classList.toggle('active', !!match);
+          group.setAttribute('aria-hidden', match ? 'false' : 'true');
+          if(match){
+            activeCount += 1;
+          } else {
+            resetServiceGroup(group);
           }
         });
+        serviceDetailsWrapper.classList.toggle('visible', activeCount > 0);
+        serviceDetailsWrapper.setAttribute('aria-hidden', activeCount > 0 ? 'false' : 'true');
       }
 
-      function calculateTotal(){
+      function calculateTotals(){
         const serviceKey = serviceSelect.value;
         const sqftKey = sqftSelect.value;
         if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
-          basePriceEl.textContent = '—';
-          totalPriceEl.textContent = '—';
-          return;
+          return { ready: false, base: 0, detail: 0, total: 0, selections: {} };
         }
 
         const base = basePricing[serviceKey][sqftKey] || 0;
-        let total = base;
+        let detailAdjustment = 0;
+        const selections = {};
 
-        addonPills.forEach(pill => {
-          if(!pill.classList.contains('active')) return;
-          const parent = pill.closest('.addon-group');
-          if(!parent || !parent.classList.contains('active')) return;
+        if(serviceKey === 'home'){
+          const roomsField = document.getElementById('home-rooms');
+          const bathField = document.getElementById('home-bathrooms');
+          const petsField = document.getElementById('home-pets');
 
-          const price = Number(pill.dataset.price || 0);
-          const qtyInput = pill.querySelector('.addon-qty');
-          const qty = qtyInput ? Math.max(1, Number(qtyInput.value) || 1) : 1;
-          total += price * qty;
-        });
+          if(roomsField && roomsField.value){
+            detailAdjustment += detailPricing.home.rooms[roomsField.value] || 0;
+            selections.homeRooms = {
+              value: roomsField.value,
+              label: roomsField.selectedOptions[0] ? roomsField.selectedOptions[0].text : roomsField.value
+            };
+          }
+          if(bathField && bathField.value){
+            detailAdjustment += detailPricing.home.bathrooms[bathField.value] || 0;
+            selections.homeBathrooms = {
+              value: bathField.value,
+              label: bathField.selectedOptions[0] ? bathField.selectedOptions[0].text : bathField.value
+            };
+          }
+          if(petsField && petsField.value){
+            detailAdjustment += detailPricing.home.pets[petsField.value] || 0;
+            selections.homePets = {
+              value: petsField.value,
+              label: petsField.value === 'yes' ? 'Yes' : 'No'
+            };
+          }
+        }
 
-        basePriceEl.textContent = base ? `$${base.toFixed(0)}` : '—';
-        totalPriceEl.textContent = total ? `$${total.toFixed(0)}` : '—';
+        if(serviceKey === 'office'){
+          const officeField = document.getElementById('office-offices');
+          const officeBathField = document.getElementById('office-bathrooms');
+
+          if(officeField && officeField.value){
+            detailAdjustment += detailPricing.office.offices[officeField.value] || 0;
+            selections.officeOffices = {
+              value: officeField.value,
+              label: officeField.selectedOptions[0] ? officeField.selectedOptions[0].text : officeField.value
+            };
+          }
+          if(officeBathField && officeBathField.value){
+            detailAdjustment += detailPricing.office.bathrooms[officeBathField.value] || 0;
+            selections.officeBathrooms = {
+              value: officeBathField.value,
+              label: officeBathField.selectedOptions[0] ? officeBathField.selectedOptions[0].text : officeBathField.value
+            };
+          }
+        }
+
+        return {
+          ready: true,
+          base,
+          detail: detailAdjustment,
+          total: base + detailAdjustment,
+          selections
+        };
       }
 
-      function toggleCustomize(){
-        const ready = hasAllRequired();
-        customizeBlock.classList.toggle('visible', ready);
-        customizeBlock.setAttribute('aria-hidden', ready ? 'false' : 'true');
-        form.classList.toggle('quote-ready', ready);
-        if(!ready){
+      function updateTotals(){
+        const totals = calculateTotals();
+
+        if(!totals.ready){
           basePriceEl.textContent = '—';
           totalPriceEl.textContent = '—';
-          resetAddons();
+          if(detailSummaryRow && detailSummaryEl){
+            detailSummaryRow.hidden = true;
+            detailSummaryEl.textContent = '—';
+          }
         } else {
-          updateAddonAvailability(serviceSelect.value);
-          calculateTotal();
+          basePriceEl.textContent = `$${totals.base.toFixed(0)}`;
+          totalPriceEl.textContent = `$${totals.total.toFixed(0)}`;
+          if(detailSummaryRow && detailSummaryEl){
+            if(totals.detail > 0){
+              detailSummaryRow.hidden = false;
+              detailSummaryEl.textContent = `$${totals.detail.toFixed(0)}`;
+            } else {
+              detailSummaryRow.hidden = true;
+              detailSummaryEl.textContent = '—';
+            }
+          }
         }
+
+        const ready = hasAllRequired() && totals.ready;
+        form.classList.toggle('quote-ready', ready);
+        if(seePriceBtn){
+          seePriceBtn.disabled = !ready;
+        }
+
+        return totals;
       }
 
-      addonPills.forEach(pill => {
-        pill.addEventListener('click', (event) => {
-          if(!customizeBlock.classList.contains('visible')) return;
-          const qtyInput = pill.querySelector('.addon-qty');
-          if(event.target === qtyInput) return;
-
-          pill.classList.toggle('active');
-          if(qtyInput){
-            qtyInput.disabled = !pill.classList.contains('active');
+      choiceButtons.forEach(button => {
+        const targetId = button.dataset.target;
+        const hiddenInput = targetId ? document.getElementById(targetId) : null;
+        if(!hiddenInput) return;
+        button.setAttribute('aria-pressed', 'false');
+        button.addEventListener('click', () => {
+          const group = button.closest('.choice-buttons');
+          if(group){
+            const buttons = Array.from(group.querySelectorAll('.choice-button'));
+            buttons.forEach(btn => {
+              const isActive = btn === button;
+              btn.classList.toggle('active', isActive);
+              btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
           }
-          pill.setAttribute('aria-pressed', pill.classList.contains('active') ? 'true' : 'false');
-          calculateTotal();
+          hiddenInput.value = button.dataset.value || '';
+          updateTotals();
         });
-
-        const qtyInput = pill.querySelector('.addon-qty');
-        if(qtyInput){
-          qtyInput.disabled = true;
-          qtyInput.addEventListener('input', () => {
-            if(!pill.classList.contains('active')) return;
-            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min)){
-              qtyInput.value = qtyInput.min;
-            }
-            calculateTotal();
-          });
-        }
-
-        pill.addEventListener('keydown', (evt) => {
-          if(evt.key === 'Enter' || evt.key === ' '){
-            evt.preventDefault();
-            pill.click();
-          }
-        });
-        pill.setAttribute('tabindex', '0');
-        pill.setAttribute('role', 'button');
-        pill.setAttribute('aria-pressed', 'false');
       });
 
       requiredFields.forEach(field => {
         const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
-        field.addEventListener(eventName, toggleCustomize);
+        field.addEventListener(eventName, updateTotals);
       });
 
       serviceSelect.addEventListener('change', () => {
-        updateAddonAvailability(serviceSelect.value);
-        calculateTotal();
+        updateServiceDetails(serviceSelect.value);
+        updateTotals();
       });
 
-      sqftSelect.addEventListener('change', calculateTotal);
-
-      addonPills.forEach(pill => {
-        pill.setAttribute('aria-pressed', 'false');
+      sqftSelect.addEventListener('change', () => {
+        updateTotals();
       });
 
-      toggleCustomize();
+      if(seePriceBtn){
+        seePriceBtn.addEventListener('click', () => {
+          if(seePriceBtn.disabled) return;
+          const totals = updateTotals();
+          if(!totals.ready) return;
+
+          const url = new URL('book.html', window.location.origin);
+          const params = url.searchParams;
+
+          const serviceOption = serviceSelect.selectedOptions[0];
+          const sqftOption = sqftSelect.selectedOptions[0];
+
+          params.set('service', serviceSelect.value);
+          if(serviceOption){ params.set('serviceLabel', serviceOption.text); }
+
+          params.set('sqft', sqftSelect.value);
+          if(sqftOption){ params.set('sqftLabel', sqftOption.text); }
+
+          params.set('basePrice', totals.base.toFixed(2));
+          params.set('detailPrice', totals.detail.toFixed(2));
+          params.set('total', totals.total.toFixed(2));
+
+          const firstName = document.getElementById('quote-first-name');
+          if(firstName && firstName.value.trim()){
+            params.set('firstName', firstName.value.trim());
+          }
+
+          const email = document.getElementById('quote-email');
+          if(email && email.value.trim()){
+            params.set('email', email.value.trim());
+          }
+
+          Object.entries(totals.selections || {}).forEach(([key, info]) => {
+            if(info.value){ params.set(key, info.value); }
+            if(info.label){ params.set(`${key}Label`, info.label); }
+          });
+
+          window.location.href = `${url.toString()}#start`;
+        });
+      }
+
+      updateServiceDetails(serviceSelect.value);
+      updateTotals();
     })();
   </script>
 

--- a/style.css
+++ b/style.css
@@ -177,7 +177,12 @@ h1, h2, h3 {
 }
 
 /* Headline */
-.headline { font-size: 3rem; font-weight: 800; line-height: 1.2; }
+.headline {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1.2;
+  margin-top: clamp(1.75rem, 4vw, 3.5rem);
+}
 .headline span { display: inline-block; animation: fadeIn 1s ease forwards; opacity: 0; }
 .headline span:nth-child(1){animation-delay:.3s}
 .headline span:nth-child(2){animation-delay:.6s}
@@ -307,6 +312,83 @@ h1, h2, h3 {
   transform: translateY(-1px);
 }
 
+.service-details {
+  display: none;
+  margin-top: 0.5rem;
+  border-radius: 24px;
+  border: 1px solid rgba(0, 212, 255, 0.18);
+  background: rgba(8, 19, 32, 0.55);
+  padding: 1.35rem 1.5rem;
+  box-shadow: inset 0 0 22px rgba(0, 212, 255, 0.08);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.service-details.visible {
+  display: grid;
+  gap: 1.5rem;
+  opacity: 1;
+}
+
+.service-detail-group {
+  display: none;
+  gap: 1.1rem;
+}
+
+.service-detail-group.active {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.service-detail-title {
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(173, 214, 255, 0.75);
+  margin-bottom: 0.75rem;
+}
+
+.service-detail-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.field-choice .choice-buttons {
+  display: flex;
+  gap: 0.65rem;
+}
+
+.choice-button {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  border: 1.5px solid rgba(0, 212, 255, 0.25);
+  background: rgba(8, 19, 32, 0.6);
+  color: #f2fbff;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, transform 0.25s ease;
+}
+
+.choice-button:hover,
+.choice-button:focus-visible {
+  border-color: rgba(0, 212, 255, 0.65);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.choice-button.active {
+  background: rgba(0, 212, 255, 0.22);
+  border-color: rgba(0, 212, 255, 0.6);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+}
+
+.choice-button:focus {
+  outline: none;
+}
+
 .quote-summary {
   padding: 1.2rem 1.4rem;
   border-radius: 24px;
@@ -317,6 +399,42 @@ h1, h2, h3 {
   gap: 0.85rem;
   opacity: 0.55;
   transition: opacity 0.35s ease;
+}
+
+.quote-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+.quote-see-price {
+  appearance: none;
+  border-radius: 18px;
+  border: 1.5px solid rgba(0, 212, 255, 0.35);
+  background: linear-gradient(180deg, rgba(0, 212, 255, 0.25), rgba(0, 212, 255, 0.1));
+  color: #f2fbff;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.85rem 1.8rem;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, transform 0.25s ease, color 0.25s ease;
+}
+
+.quote-see-price:not(:disabled):hover,
+.quote-see-price:not(:disabled):focus-visible {
+  border-color: rgba(0, 212, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  background: linear-gradient(180deg, rgba(0, 212, 255, 0.45), rgba(0, 212, 255, 0.2));
+  transform: translateY(-1px);
+}
+
+.quote-see-price:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  background: rgba(8, 19, 32, 0.45);
+  border-color: rgba(0, 212, 255, 0.18);
+  color: rgba(214, 238, 255, 0.6);
 }
 
 .quote-form.quote-ready .quote-summary {
@@ -391,29 +509,35 @@ h1, h2, h3 {
   display: none;
 }
 
+
 .addon-group.active {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
 }
 
 .addon-pill {
+  position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  justify-content: center;
+  gap: 0.35rem;
+  width: 80px;
+  min-height: 80px;
+  padding: 0.45rem 0.5rem;
   border-radius: 999px;
   background: rgba(16, 32, 48, 0.6);
   border: 1.5px solid rgba(0, 212, 255, 0.18);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.38);
   cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  text-align: center;
 }
 
 .addon-pill:hover {
-  transform: scale(1.06);
-  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.45);
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
 }
 
 .addon-pill.active {
@@ -421,25 +545,28 @@ h1, h2, h3 {
   box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.25), 0 22px 40px rgba(0, 0, 0, 0.55);
 }
 
+
 .addon-icon {
-  font-size: 1.35rem;
+  font-size: 1.4rem;
   flex-shrink: 0;
 }
 
 .addon-name {
-  flex: 1;
-  font-size: 1rem;
+  font-size: 0.68rem;
+  line-height: 1.1;
   color: rgba(226, 245, 255, 0.9);
+  word-break: break-word;
 }
 
 .addon-qty {
-  width: 3.5rem;
-  padding: 0.4rem 0.5rem;
-  border-radius: 14px;
+  width: 100%;
+  max-width: 62px;
+  padding: 0.25rem 0.4rem;
+  border-radius: 999px;
   border: 1.5px solid rgba(0, 212, 255, 0.35);
   background: rgba(6, 20, 32, 0.75);
   color: #f2fbff;
-  font-size: 1rem;
+  font-size: 0.75rem;
   transition: border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
@@ -448,6 +575,7 @@ h1, h2, h3 {
   border-color: rgba(0, 212, 255, 0.7);
   box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
 }
+
 
 .addon-pill:not(.active) .addon-qty {
   opacity: 0.4;
@@ -489,20 +617,22 @@ h1, h2, h3 {
   }
 
   .addon-group.active {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(68px, 1fr));
   }
 
   .addon-pill {
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    width: 68px;
+    min-height: 68px;
+    padding: 0.35rem;
+    gap: 0.28rem;
   }
 
   .addon-name {
-    flex-basis: 100%;
+    font-size: 0.62rem;
   }
 
   .addon-qty {
-    width: 100%;
+    font-size: 0.7rem;
   }
 }
 .services-btn-home:hover { background:#00d4ff; color:#000; transform: translateY(-2px); box-shadow: 0 8px 20px rgba(0,212,255,.3); }


### PR DESCRIPTION
## Summary
- streamline the home-page quote so it only captures base package details and hands off to booking via a See My Price button
- restyle the quote actions to match the compact UI while preparing the new booking workflow entry point
- rebuild book.html around a shared summary card, frequency picker, and add-on step that apply pricing adjustments through the booking flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e183836ec88320a011a1b38925ff6f