### PR TITLE
Refine quote selects and streamline booking layout

### DIFF
--- a/book.html
+++ b/book.html
@@ -6,28 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Book Online — DufferinDeepClean</title>
 
-  <!-- Fonts (match index + About Us script) -->
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;800&family=Great+Vibes&display=swap" rel="stylesheet" />
-
-  <!-- Site CSS (keep your existing file) -->
   <link rel="stylesheet" href="style.css" />
 
-  <!-- Page-specific styles to: 
-       1) match index animated background (slightly darker here),
-       2) unify logo font + animation,
-       3) keep your booking UI exactly as-is otherwise. -->
   <style>
-    /* ===== Animated seamless background (same as index, slightly darker) ===== */
     :root{
-      /* Use the same seamless tile image you use on index */
-      --bg-tile: url('backgroundbook.png');    /* or cleaning-pattern.png if that’s your tile */
+      --bg-tile: url('backgroundbook.png');
       --tile-w: 1536px;
       --tile-h: 1024px;
       --tile-scale: 0.90;
       --tile-w-size: calc(var(--tile-w) * var(--tile-scale));
       --tile-h-size: calc(var(--tile-h) * var(--tile-scale));
-
-      /* Darker overlay than index (index ≈ 0.40/0.66/0.80) */
       --overlay-a: rgba(0,0,0,0.52);
       --overlay-b: rgba(0,0,0,0.78);
       --overlay-c: rgba(0,0,0,0.90);
@@ -40,7 +29,6 @@
       background: transparent !important;
     }
 
-    /* Animated tile layer (under content) */
     body::after{
       content:"";
       position: fixed; inset: 0; z-index: 0; pointer-events: none;
@@ -55,22 +43,18 @@
       to   { background-position: var(--tile-w-size) var(--tile-h-size); }
     }
 
-    /* Darker readability overlay for booking page */
     body::before{
       content:"";
       position: fixed; inset: 0; z-index: 1; pointer-events: none;
-      background: radial-gradient(1200px 600px at 50% -10%,
-                  var(--overlay-a), var(--overlay-b) 60%, var(--overlay-c));
+      background: radial-gradient(1200px 600px at 50% -10%, var(--overlay-a), var(--overlay-b) 60%, var(--overlay-c));
     }
 
-    /* Ensure all content sits above background layers */
     .navbar, main, section, footer { position: relative; z-index: 2; }
 
-    /* ===== NAV: transparent like index, unified logo font + left→right unveil ===== */
     .navbar{
       display:flex; justify-content:space-between; align-items:center;
       padding: 14px 22px;
-      background: rgba(0,0,0,0.20);           /* transparent header over the moving bg */
+      background: rgba(0,0,0,0.20);
       backdrop-filter: blur(6px);
       border-bottom: 1px solid rgba(255,255,255,0.08);
       position: sticky; top: 0; z-index: 1000;
@@ -78,7 +62,7 @@
     .logo{ display:flex; align-items:center; gap:.55rem; }
     .logo .soap{ font-size: 2.2rem; transform: translateY(2px); }
     .logo .logo-text{
-      font-family: 'Great Vibes', cursive !important;  /* match About Us */
+      font-family: 'Great Vibes', cursive !important;
       font-size: 2.8rem; line-height: 1; letter-spacing: .4px; color:#fff;
       position:relative; display:inline-block;
       clip-path: inset(0 100% 0 0); opacity:0;
@@ -94,7 +78,6 @@
       animation: logoSweep 1.1s ease forwards .25s;
     }
 
-    /* Nav links match site look */
     .nav-links a{
       font-family: 'Bebas Neue', sans-serif;
       letter-spacing: .5px;
@@ -103,7 +86,6 @@
     }
     .nav-links a:hover{ color:#fff; }
 
-    /* ===== Booking page layout (your original UI, unchanged) ===== */
     .booking{
       max-width: 1100px; margin: 0 auto;
       padding: clamp(20px, 4vw, 48px);
@@ -126,10 +108,11 @@
       border-radius: 16px;
       box-shadow: 0 10px 30px rgba(0,0,0,0.35);
       backdrop-filter: blur(6px);
+      text-transform: lowercase;
     }
     .stepper li{
       padding: 14px 12px; text-align: center; border-radius: 12px;
-      font-weight: 600; text-transform: lowercase; color: #b6c2cf;
+      font-weight: 600; color: #b6c2cf;
       border: 1px dashed rgba(255,255,255,0.12);
       transition: transform .2s ease, background .2s ease, color .2s ease, border-color .2s ease;
     }
@@ -139,26 +122,113 @@
       background: linear-gradient(180deg, rgba(0,208,132,0.12), rgba(0,208,132,0.05));
     }
     .stepper li.active{
-      color: #111; 
-      background: linear-gradient(180deg, #ffd166, #ffb703);
-      border-color: rgba(255,183,3,0.65);
+      color: #fff;
+      background: linear-gradient(180deg, #ff90dc, #ff4fc3);
+      border-color: rgba(255, 128, 210, 0.7);
+      box-shadow: 0 12px 28px rgba(255, 110, 205, 0.25);
       transform: translateY(-1px);
     }
 
     .booking-card{
       margin: 18px auto 0; width: min(100%, 1050px);
-      background: rgba(10, 12, 16, 0.72);     /* slightly darker card to match page darkness */
+      background: rgba(10, 12, 16, 0.72);
       border: 1px solid rgba(255,255,255,0.08);
       border-radius: 20px;
       box-shadow: 0 20px 50px rgba(0,0,0,0.45);
       backdrop-filter: blur(8px);
       overflow: hidden;
     }
-    .booking-form, .booking-success{ padding: clamp(16px, 3vw, 28px); }
+    .booking-layout{
+      display: grid;
+      gap: clamp(18px, 3vw, 32px);
+      padding: clamp(18px, 3vw, 32px);
+    }
+    @media (min-width: 960px){
+      .booking-layout{
+        grid-template-columns: minmax(260px, 320px) 1fr;
+        align-items: flex-start;
+      }
+    }
+    .booking-form{
+      padding: 0;
+      display: grid;
+      gap: clamp(18px, 3vw, 28px);
+    }
+    .booking-success{ padding: clamp(16px, 3vw, 28px); }
 
     fieldset{ border: none; margin: 0; padding: 0; }
     legend{ font-weight: 800; font-size: 1.2rem; margin-bottom: 14px; }
     .muted{ color: #b6c2cf; }
+
+    .booking-summary-panel{
+      background: linear-gradient(180deg, rgba(12, 42, 30, 0.85), rgba(8, 30, 24, 0.7));
+      border: 1px solid rgba(64, 255, 180, 0.45);
+      border-radius: 22px;
+      box-shadow: 0 24px 50px rgba(0,0,0,0.4);
+      padding: clamp(16px, 2.4vw, 24px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(14px, 2vw, 18px);
+    }
+    .booking-summary-title{
+      font-family: 'Bebas Neue', sans-serif;
+      font-size: clamp(1.8rem, 3vw, 2.2rem);
+      letter-spacing: 0.16em;
+      text-transform: lowercase;
+      margin: 0;
+    }
+    .summary-note{
+      margin: 0;
+      font-size: 0.9rem;
+      color: rgba(207, 224, 238, 0.78);
+    }
+    .summary-details{
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.45rem;
+      font-size: 0.9rem;
+      color: rgba(214, 238, 255, 0.85);
+    }
+    .summary-details li{
+      position: relative;
+      padding-left: 1.1rem;
+      line-height: 1.5;
+    }
+    .summary-details li::before{
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0.55rem;
+      width: 0.45rem;
+      height: 0.45rem;
+      border-radius: 50%;
+      background: rgba(64, 255, 180, 0.65);
+      box-shadow: 0 0 6px rgba(64, 255, 180, 0.5);
+    }
+    .summary-details strong{ color: #f7fdff; font-weight: 700; }
+    .summary-placeholder{
+      color: rgba(207, 224, 238, 0.6);
+      font-style: italic;
+    }
+    .summary-placeholder::before{
+      background: rgba(207, 224, 238, 0.45);
+      box-shadow: none;
+    }
+    .booking-summary-panel .quote-summary{ 
+      opacity: 1;
+      background: rgba(10, 32, 24, 0.72);
+      border: 1px solid rgba(64, 255, 180, 0.35);
+      box-shadow: inset 0 0 18px rgba(64, 255, 180, 0.12);
+    }
+    .booking-summary-panel .quote-summary-line strong{
+      text-shadow: 0 0 12px rgba(64, 255, 180, 0.35);
+      color: #eafff5;
+    }
+    .booking-summary-panel .quote-summary-line.total strong{
+      color: #b8ffe6;
+    }
 
     .grid-2{ display: grid; gap: 14px; grid-template-columns: 1fr; }
     .grid-2 .wide{ grid-column: 1 / -1; }
@@ -204,13 +274,6 @@
     }
     .btn:hover{ filter: brightness(1.05); }
 
-    .package-desc{
-      border: 1px dashed rgba(255,255,255,0.2);
-      border-radius: 12px;
-      padding: 12px;
-      background: rgba(255,255,255,0.03);
-    }
-
     .review{
       display:grid; gap:10px;
       border: 1px solid rgba(255,255,255,0.08);
@@ -220,10 +283,148 @@
     }
     .review dt{ font-weight: 700; color: #b6c2cf; }
     .review dd{ margin: 0 0 10px; }
+
+    .addon-empty{ color: rgba(214, 238, 255, 0.7); font-size: 0.95rem; }
+
+    .payment-wall{
+      display: grid;
+      gap: clamp(16px, 3vw, 24px);
+      padding: clamp(18px, 3vw, 26px);
+      border-radius: 18px;
+      border: 1px solid rgba(0,212,255,0.18);
+      background: linear-gradient(160deg, rgba(6, 24, 36, 0.85), rgba(4, 16, 28, 0.65));
+      box-shadow: 0 24px 60px rgba(0,0,0,0.45);
+    }
+    @media (min-width: 960px){
+      .payment-wall{
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+        align-items: start;
+      }
+      .payment-wall .payment-guides,
+      .payment-wall .review{
+        grid-column: 1 / -1;
+      }
+    }
+    .payment-overview{
+      display: grid;
+      gap: clamp(14px, 3vw, 20px);
+      background: rgba(4, 18, 28, 0.6);
+      border: 1px solid rgba(0,212,255,0.16);
+      border-radius: 16px;
+      padding: clamp(14px, 2.5vw, 20px);
+    }
+    @media (min-width: 720px){
+      .payment-overview{
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+        align-items: flex-start;
+      }
+    }
+    .payment-policy h3{
+      margin: 0 0 0.5rem;
+      font-size: 1.1rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #eaf9ff;
+    }
+    .payment-policy p{
+      margin: 0;
+      color: rgba(214, 238, 255, 0.8);
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+    .payment-breakdown{
+      display: grid;
+      gap: 0.4rem;
+      color: rgba(214, 238, 255, 0.86);
+      font-size: 0.95rem;
+    }
+    .payment-breakdown .label{ color: rgba(214, 238, 255, 0.7); text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.75rem; margin-right: 0.35rem; }
+    .payment-breakdown strong{ font-size: 1.05rem; color: #f7fffe; }
+    .payment-deposit-note{ margin: 0; font-size: 0.85rem; color: rgba(214, 238, 255, 0.7); }
+
+    .payment-methods{
+      border: 1px solid rgba(0,212,255,0.14);
+      border-radius: 16px;
+      padding: clamp(14px, 2.5vw, 20px);
+      background: rgba(2, 12, 20, 0.55);
+    }
+    .payment-methods .sublegend{
+      font-size: 0.95rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 0.75rem;
+      color: rgba(214, 238, 255, 0.78);
+    }
+    .payment-option{
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.75rem;
+      align-items: start;
+      padding: 0.65rem 0;
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .payment-option:last-of-type{ border-bottom: none; }
+    .payment-option input{ margin-top: 0.35rem; }
+    .payment-option-card{
+      display: grid;
+      gap: 0.35rem;
+      background: linear-gradient(150deg, rgba(0, 44, 66, 0.55), rgba(0, 18, 30, 0.65));
+      border: 1px solid rgba(255,255,255,0.05);
+      border-radius: 12px;
+      padding: 0.65rem 0.8rem;
+      transition: border-color .2s ease, box-shadow .2s ease;
+    }
+    .payment-option input:checked + .payment-option-card{
+      border-color: rgba(0,212,255,0.5);
+      box-shadow: 0 18px 32px rgba(0,0,0,0.4);
+    }
+    .payment-option-title{ font-weight: 700; color: #f5fbff; }
+    .payment-option-note{ color: rgba(214, 238, 255, 0.75); font-size: 0.9rem; line-height: 1.5; }
+    .payment-option-note a{ color: #7ce9ff; }
+
+    .payment-guides{
+      border: 1px dashed rgba(0,212,255,0.22);
+      border-radius: 16px;
+      padding: clamp(12px, 2vw, 18px);
+      background: rgba(4, 18, 28, 0.45);
+      display: grid;
+      gap: 0.6rem;
+    }
+    .payment-guides h3{
+      margin: 0;
+      font-size: 1rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #e6f8ff;
+    }
+    .payment-guides p{ margin: 0; color: rgba(214, 238, 255, 0.72); font-size: 0.88rem; }
+    .payment-guides-list{
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.45rem;
+    }
+    .payment-guides-list li{
+      font-size: 0.88rem;
+      color: rgba(214, 238, 255, 0.78);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      align-items: baseline;
+    }
+    .payment-guides-list a{ color: #7ce9ff; }
+
+    .payment-wall .review{
+      background: rgba(2, 12, 20, 0.55);
+      border-color: rgba(0,212,255,0.14);
+      padding: clamp(12px, 2.5vw, 18px);
+    }
+    .payment-wall .review dt{ color: rgba(173, 214, 255, 0.78); }
+    .payment-wall .review dd{ color: #f2f5f8; }
   </style>
 </head>
 <body>
-  <!-- NAV -->
   <header class="navbar">
     <div class="logo">
       <span class="soap">🧼</span>
@@ -236,26 +437,270 @@
     </nav>
   </header>
 
-  <section class="booking">
+  <section class="booking" id="start">
     <h1 class="booking-title">book online</h1>
 
-    <!-- Long, centered step rectangle -->
     <div class="stepper-wrap">
       <ol class="stepper" id="stepper">
-        <li class="active">1. when &amp; where</li>
-        <li>2. how often</li>
-        <li>3. cleaning type</li>
+        <li class="active">1. price summary</li>
+        <li>2. add extras</li>
+        <li>3. when &amp; where</li>
         <li>4. your details</li>
         <li>5. review &amp; confirm</li>
       </ol>
     </div>
 
-    <!-- Application card -->
     <div class="booking-card">
-      <form id="bookingForm" class="booking-form" action="https://formspree.io/f/mrblyqpr" method="POST">
-        <!-- STEP 1: When & Where -->
-        <fieldset class="step" data-step="1">
-          <legend>When &amp; Where</legend>
+      <div class="booking-layout" id="bookingLayout">
+        <aside class="booking-summary-panel" aria-labelledby="booking-summary-title">
+          <h2 id="booking-summary-title" class="booking-summary-title">price summary</h2>
+          <p class="summary-note" id="summary-frequency-note">Start with an instant quote to unlock pricing.</p>
+          <div class="quote-summary" id="booking-summary" aria-live="polite">
+            <div class="quote-summary-line">
+              <span>Base Package</span>
+              <strong id="summary-base-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-detail-row" hidden>
+              <span>Service Details</span>
+              <strong id="summary-detail-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-extras-row" hidden>
+              <span>Add-ons</span>
+              <strong id="summary-extras-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-discount-row" hidden>
+              <span>Frequency Savings</span>
+              <strong id="summary-discount-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-deposit-row" hidden>
+              <span>Deposit Due Today (50%)</span>
+              <strong id="summary-deposit-price">—</strong>
+            </div>
+            <div class="quote-summary-line" id="summary-balance-row" hidden>
+              <span>Balance at Service</span>
+              <strong id="summary-balance-price">—</strong>
+            </div>
+            <div class="quote-summary-line total">
+              <span>Estimated Visit Total</span>
+              <strong id="summary-total-price">—</strong>
+            </div>
+          </div>
+          <ul class="summary-details" id="summary-detail-list">
+            <li class="summary-placeholder">Your base package selections will appear here once you start an instant quote.</li>
+          </ul>
+        </aside>
+
+        <form id="bookingForm" class="booking-form" action="https://formspree.io/f/mrblyqpr" method="POST">
+
+          <input type="hidden" name="service_key" id="input-service-key">
+          <input type="hidden" name="service_label" id="input-service-label">
+          <input type="hidden" name="square_footage_range" id="input-sqft-label">
+          <input type="hidden" name="detail_summary" id="input-detail-summary">
+          <input type="hidden" name="base_package_price" id="input-base-price">
+          <input type="hidden" name="service_detail_price" id="input-detail-price">
+          <input type="hidden" name="addons_price" id="input-addons-price">
+          <input type="hidden" name="frequency_savings" id="input-discount-price">
+          <input type="hidden" name="deposit_due" id="input-deposit-price">
+          <input type="hidden" name="balance_due" id="input-balance-price">
+          <input type="hidden" name="final_visit_total" id="input-total-price">
+          <input type="hidden" name="selected_addons" id="input-selected-addons">
+          <input type="hidden" name="origin_quote" id="input-origin" value="">
+          <input type="hidden" name="package" id="input-package">
+
+          <fieldset class="step" data-step="1">
+          <legend>Your base package</legend>
+          <p class="muted">Review the base price we created from your instant quote and choose how often you'd like us to clean.</p>
+          <div class="plans">
+            <label class="plan">
+              <input type="radio" name="frequency" value="weekly" data-discount="0.25" required />
+              <div class="plan-card">
+                <div class="plan-title">Weekly</div>
+                <div class="plan-discount">25% off</div>
+                <div class="plan-note">Best value &amp; consistency</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="biweekly" data-discount="0.20" />
+              <div class="plan-card">
+                <div class="plan-title">Bi-Weekly</div>
+                <div class="plan-discount">20% off</div>
+                <div class="plan-note">Great for busy offices</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="triweekly" data-discount="0.15" />
+              <div class="plan-card">
+                <div class="plan-title">Tri-Weekly</div>
+                <div class="plan-discount">15% off</div>
+                <div class="plan-note">Light traffic spaces</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="monthly" data-discount="0.10" />
+              <div class="plan-card">
+                <div class="plan-title">Monthly</div>
+                <div class="plan-discount">10% off</div>
+                <div class="plan-note">Deep refresh once a month</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="biannual" data-discount="0.05" />
+              <div class="plan-card">
+                <div class="plan-title">Biannual</div>
+                <div class="plan-discount">5% off</div>
+                <div class="plan-note">Seasonal top-to-bottom</div>
+              </div>
+            </label>
+            <label class="plan">
+              <input type="radio" name="frequency" value="onetime" data-discount="0" />
+              <div class="plan-card">
+                <div class="plan-title">One-time</div>
+                <div class="plan-discount">Standard rate</div>
+                <div class="plan-note">Perfect for move-ins &amp; projects</div>
+              </div>
+            </label>
+          </div>
+          <div class="actions">
+            <button type="button" class="btn next">Next</button>
+          </div>
+        </fieldset>
+
+        <fieldset class="step" data-step="2" hidden>
+          <legend>Add extra services</legend>
+          <p class="muted">Add speciality tasks for this visit. Select a tile to include it and adjust the quantity if needed.</p>
+          <div class="addon-groups" id="addon-groups">
+            <div class="addon-group" data-service-group="home">
+              <p class="addon-group-title">Home &amp; Residential Extras</p>
+              <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
+                <span class="addon-icon">✨</span>
+                <span class="addon-name">Deep Clean Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
+              </div>
+              <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
+                <span class="addon-icon">🚚</span>
+                <span class="addon-name">Move In/Out Clean Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
+              </div>
+              <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
+                <span class="addon-icon">🛠️</span>
+                <span class="addon-name">Renovation Clean Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
+              </div>
+              <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
+                <span class="addon-icon">🎓</span>
+                <span class="addon-name">Move In/Out Package (Student Property)</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
+              </div>
+              <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
+                <span class="addon-icon">🏠</span>
+                <span class="addon-name">AirBnB Listing</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
+              </div>
+              <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
+                <span class="addon-icon">🐾</span>
+                <span class="addon-name">I have Pets</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
+              </div>
+              <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
+                <span class="addon-icon">🧊</span>
+                <span class="addon-name">Inside Fridge</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
+              </div>
+              <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
+                <span class="addon-icon">🔥</span>
+                <span class="addon-name">Inside Oven</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
+              </div>
+              <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
+                <span class="addon-icon">🗄️</span>
+                <span class="addon-name">Inside Cabinets</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
+              </div>
+              <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
+                <span class="addon-icon">🍽️</span>
+                <span class="addon-name">Additional Kitchen</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
+              </div>
+              <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
+                <span class="addon-icon">🪟</span>
+                <span class="addon-name">Blinds (per window)</span>
+                <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
+              </div>
+              <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
+                <span class="addon-icon">🔍</span>
+                <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
+                <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
+              </div>
+              <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
+                <span class="addon-icon">🔎</span>
+                <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
+                <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
+              </div>
+              <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
+                <span class="addon-icon">🪟</span>
+                <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
+                <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
+              </div>
+              <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
+                <span class="addon-icon">🛏️</span>
+                <span class="addon-name">Change Bed Sheets + Load Laundry</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
+              </div>
+              <div class="addon-pill color-crimson" data-addon="Load Dishwasher" data-price="10">
+                <span class="addon-icon">🍽️</span>
+                <span class="addon-name">Load Dishwasher</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
+              </div>
+              <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
+                <span class="addon-icon">🧴</span>
+                <span class="addon-name">Sanitization Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
+              </div>
+            </div>
+
+            <div class="addon-group" data-service-group="commercial,office">
+              <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
+              <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
+                <span class="addon-icon">🧼</span>
+                <span class="addon-name">Carpet Steam Cleaning Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
+              </div>
+              <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
+                <span class="addon-icon">🧽</span>
+                <span class="addon-name">Tile and Grout Cleaning Package</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout Cleaning quantity">
+              </div>
+              <div class="addon-pill color-mint" data-addon="Restock Bathroom Supply" data-price="40">
+                <span class="addon-icon">🧻</span>
+                <span class="addon-name">Restock Bathroom Supply</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Restock Bathroom Supply quantity">
+              </div>
+              <div class="addon-pill color-gold" data-addon="Disinfect Electronics" data-price="45">
+                <span class="addon-icon">💻</span>
+                <span class="addon-name">Disinfect Electronics</span>
+                <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Disinfect Electronics quantity">
+              </div>
+              <div class="addon-pill color-teal" data-addon="Empty Garbage/Recycling" data-price="18">
+                <span class="addon-icon">🗑️</span>
+                <span class="addon-name">Empty Garbage/Recycling</span>
+                <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Empty Garbage/Recycling quantity">
+              </div>
+              <div class="addon-pill color-lime" data-addon="Water Plants" data-price="15">
+                <span class="addon-icon">🌿</span>
+                <span class="addon-name">Water Plants</span>
+                <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Water Plants quantity">
+              </div>
+            </div>
+          </div>
+          <p class="addon-empty" id="addon-empty-message" hidden>No add-ons available for this service. Continue to scheduling.</p>
+          <div class="actions">
+            <button type="button" class="btn back">Back</button>
+            <button type="button" class="btn next">Next</button>
+          </div>
+        </fieldset>
+
+        <fieldset class="step" data-step="3" hidden>
+          <legend>When &amp; where</legend>
           <div class="grid-2">
             <label>
               Business name (optional)
@@ -283,66 +728,7 @@
             </label>
             <label class="wide">
               Approx. square footage
-              <input type="number" name="sqft" min="100" step="50" placeholder="e.g., 5,000" required />
-            </label>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn next">Next</button>
-          </div>
-        </fieldset>
-
-        <!-- STEP 2: How Often -->
-        <fieldset class="step" data-step="2" hidden>
-          <legend>How Often?</legend>
-          <p class="muted">Save on recurring cleanings. Choose a frequency.</p>
-          <div class="plans">
-            <label class="plan">
-              <input type="radio" name="frequency" value="weekly" required />
-              <div class="plan-card">
-                <div class="plan-title">Weekly</div>
-                <div class="plan-discount">25% off</div>
-                <div class="plan-note">Best value &amp; consistency</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="biweekly" />
-              <div class="plan-card">
-                <div class="plan-title">Bi-Weekly</div>
-                <div class="plan-discount">20% off</div>
-                <div class="plan-note">Great for busy offices</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="triweekly" />
-              <div class="plan-card">
-                <div class="plan-title">Tri-Weekly</div>
-                <div class="plan-discount">15% off</div>
-                <div class="plan-note">Light traffic spaces</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="monthly" />
-              <div class="plan-card">
-                <div class="plan-title">Monthly</div>
-                <div class="plan-discount">10% off</div>
-                <div class="plan-note">Routine upkeep</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="biannual" />
-              <div class="plan-card">
-                <div class="plan-title">Biannual</div>
-                <div class="plan-discount">5% off</div>
-                <div class="plan-note">Seasonal refresh</div>
-              </div>
-            </label>
-            <label class="plan">
-              <input type="radio" name="frequency" value="onetime" />
-              <div class="plan-card">
-                <div class="plan-title">One-time</div>
-                <div class="plan-discount">—</div>
-                <div class="plan-note">Deep clean on demand</div>
-              </div>
+              <input type="number" name="sqft" min="100" step="50" placeholder="e.g., 5,000" />
             </label>
           </div>
           <div class="actions">
@@ -351,66 +737,6 @@
           </div>
         </fieldset>
 
-        <!-- STEP 3: Cleaning Type + Packages -->
-        <fieldset class="step" data-step="3" hidden>
-          <legend>What type of cleaning?</legend>
-          <div class="grid-2">
-            <label class="wide">
-              Select a package
-              <select name="package" id="package" required>
-                <option value="" disabled selected>Choose a package…</option>
-                <option value="industrial">🏭 Industrial &amp; Warehouse Care</option>
-                <option value="office">🖥️ Office &amp; Corporate Cleaning</option>
-                <option value="specialty">🪟 Specialty Facility Services</option>
-              </select>
-            </label>
-
-            <!-- Industrial -->
-            <div class="package-desc" id="pkg-industrial" hidden>
-              <h4>🏭 Industrial &amp; Warehouse Care</h4>
-              <p class="muted"><strong>Tagline:</strong> Heavy-duty cleaning for high-demand environments.<br/><strong>Ideal for:</strong> Factories, distribution centers, and large-scale workspaces.</p>
-              <ul>
-                <li>High-dusting and overhead beam cleaning</li>
-                <li>Sweeping, scrubbing, and degreasing of production floors</li>
-                <li>Equipment and machinery wipe-downs</li>
-                <li>Loading dock and storage area cleaning</li>
-                <li>Restroom cleaning and sanitation for high-traffic use</li>
-              </ul>
-            </div>
-
-            <!-- Office -->
-            <div class="package-desc" id="pkg-office" hidden>
-              <h4>🖥️ Office &amp; Corporate Cleaning</h4>
-              <p class="muted"><strong>Tagline:</strong> A spotless, professional image for your business.<br/><strong>Ideal for:</strong> Offices, corporate headquarters, and professional buildings.</p>
-              <ul>
-                <li>Daily surface and workstation cleaning</li>
-                <li>Waste removal and recycling service</li>
-                <li>Floor care: vacuuming, mopping, and spot-cleaning carpets</li>
-                <li>Reception and common-area tidying</li>
-                <li>Restroom cleaning and supply replenishment</li>
-              </ul>
-            </div>
-
-            <!-- Specialty -->
-            <div class="package-desc" id="pkg-specialty" hidden>
-              <h4>🪟 Specialty Facility Services</h4>
-              <p class="muted"><strong>Tagline:</strong> Targeted deep-cleaning for the areas that matter most.<br/><strong>Ideal for:</strong> Businesses needing targeted or seasonal deep-cleaning.</p>
-              <ul>
-                <li>Window washing and glass polishing (interior &amp; exterior)</li>
-                <li>Cafeteria / lunchroom cleaning and sanitization</li>
-                <li>Washroom deep-clean and disinfection</li>
-                <li>Touchpoint sanitization (doors, handles, switches)</li>
-                <li>Post-construction or move-out cleaning</li>
-              </ul>
-            </div>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn back">Back</button>
-            <button type="button" class="btn next">Next</button>
-          </div>
-        </fieldset>
-
-        <!-- STEP 4: Contact -->
         <fieldset class="step" data-step="4" hidden>
           <legend>Your contact information</legend>
           <div class="grid-2">
@@ -437,18 +763,66 @@
           </div>
         </fieldset>
 
-        <!-- STEP 5: Review & Confirm -->
         <fieldset class="step" data-step="5" hidden>
-          <legend>Review &amp; Confirm</legend>
-          <dl class="review" id="reviewList">
-            <!-- Filled by JS -->
-          </dl>
+          <legend>Review, book &amp; pay</legend>
+          <div class="payment-wall">
+            <div class="payment-overview">
+              <div class="payment-policy">
+                <h3>Payment Policy</h3>
+                <p>A 50% deposit is required at the time of booking to secure your appointment. The remaining balance is due upon completion of the service. Deposits are non-refundable if cancellations occur within 48 hours of the scheduled cleaning.</p>
+              </div>
+              <div class="payment-breakdown">
+                <p><span class="label">Deposit Due Today:</span> <strong id="deposit-due-text">—</strong></p>
+                <p><span class="label">Balance at Service:</span> <strong id="balance-due-text">—</strong></p>
+              </div>
+              <p class="payment-deposit-note">Your deposit total updates automatically as you add services so you always see the 50% due today.</p>
+            </div>
+
+            <fieldset class="payment-methods">
+              <legend class="sublegend">Choose your payment method</legend>
+              <label class="payment-option">
+                <input type="radio" name="payment_method" value="paypal" required>
+                <span class="payment-option-card">
+                  <span class="payment-option-title">PayPal</span>
+                  <span class="payment-option-note">Use your PayPal balance or linked card. <a href="https://developer.paypal.com/docs/checkout/standard/" target="_blank" rel="noopener">Integration guide</a>.</span>
+                </span>
+              </label>
+              <label class="payment-option">
+                <input type="radio" name="payment_method" value="google-pay">
+                <span class="payment-option-card">
+                  <span class="payment-option-title">Google Pay</span>
+                  <span class="payment-option-note">Tap-to-pay convenience across devices. <a href="https://developers.google.com/pay/api/web" target="_blank" rel="noopener">Web API docs</a>.</span>
+                </span>
+              </label>
+              <label class="payment-option">
+                <input type="radio" name="payment_method" value="debit">
+                <span class="payment-option-card">
+                  <span class="payment-option-title">Direct Debit / Card on File</span>
+                  <span class="payment-option-note">Securely store a business debit or credit card for the remaining balance. <a href="https://stripe.com/docs/payments/ach-debit" target="_blank" rel="noopener">ACH / debit setup guide</a>.</span>
+                </span>
+              </label>
+            </fieldset>
+
+            <div class="payment-guides">
+              <h3>Connect your payment gateway</h3>
+              <p>Ready to accept deposits online? Use these quick-start guides to plug in the provider of your choice.</p>
+              <ul class="payment-guides-list">
+                <li><strong>PayPal Checkout:</strong> <a href="https://developer.paypal.com/docs/checkout/" target="_blank" rel="noopener">developer.paypal.com/docs/checkout/</a></li>
+                <li><strong>Google Pay on Web:</strong> <a href="https://developers.google.com/pay/api/web" target="_blank" rel="noopener">developers.google.com/pay/api/web</a></li>
+                <li><strong>ACH / Debit via Stripe:</strong> <a href="https://stripe.com/docs/payments/ach-debit" target="_blank" rel="noopener">stripe.com/docs/payments/ach-debit</a></li>
+              </ul>
+            </div>
+
+            <dl class="review" id="reviewList"></dl>
+          </div>
           <div class="actions">
             <button type="button" class="btn back">Back</button>
             <button type="submit" class="btn submit">Submit</button>
           </div>
         </fieldset>
       </form>
+
+      </div>
 
       <div id="bookingSuccess" class="booking-success" hidden>
         <h2>Thanks! Your request has been received.</h2>
@@ -458,7 +832,6 @@
     </div>
   </section>
 
-  <!-- iOS detector -->
   <script>
     (function () {
       var iOS = /iP(hone|od|ad)/.test(navigator.platform) || (navigator.userAgent.includes('Mac') && navigator.maxTouchPoints > 1);
@@ -466,62 +839,647 @@
     })();
   </script>
 
-  <!-- Booking wizard JS (unchanged, just scoped to this page) -->
+  <script>
+    (function(){
+      const quoteForms = Array.from(document.querySelectorAll('form.quote-form'));
+      if(!quoteForms.length) return;
+
+      const basePricing = {
+        home: {
+          '1000-1500': 165,
+          '1500-2000': 185,
+          '2000-2500': 215,
+          '2500-3000': 245,
+          '3000-3500': 285,
+          '3500-4000': 325
+        },
+        commercial: {
+          '1000-1500': 240,
+          '1500-2000': 285,
+          '2000-2500': 330,
+          '2500-3000': 380,
+          '3000-3500': 425,
+          '3500-4000': 470
+        },
+        office: {
+          '1000-1500': 210,
+          '1500-2000': 250,
+          '2000-2500': 295,
+          '2500-3000': 335,
+          '3000-3500': 375,
+          '3500-4000': 420
+        }
+      };
+
+      const detailPricing = {
+        home: {
+          rooms: { '1-2': 0, '3-4': 25, '5-6': 55, '7+': 85 },
+          bathrooms: { '1': 0, '2': 18, '3': 36, '4+': 54 },
+          pets: { no: 0, yes: 25 }
+        },
+        office: {
+          offices: { '1-5': 0, '6-10': 45, '11-20': 90, '21+': 135 },
+          bathrooms: { '1-2': 0, '3-4': 40, '5+': 70 }
+        }
+      };
+
+      quoteForms.forEach(setupQuoteForm);
+
+      function setupQuoteForm(form){
+        const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
+        const basePriceEl = form.querySelector('[data-quote-base]');
+        const detailRow = form.querySelector('[data-quote-detail-row]');
+        const detailPriceEl = form.querySelector('[data-quote-detail]');
+        const totalPriceEl = form.querySelector('[data-quote-total]');
+        const serviceInput = form.querySelector('input[name="service"]');
+        const sqftInput = form.querySelector('input[name="square-footage"]');
+        const serviceDetailsWrapper = form.querySelector('.service-details');
+        const detailGroups = serviceDetailsWrapper ? Array.from(serviceDetailsWrapper.querySelectorAll('[data-service-detail]')) : [];
+        const seePriceBtn = form.querySelector('.quote-see-price');
+        const pillControls = Array.from(form.querySelectorAll('[data-target-input]'));
+
+        function fieldIsRelevant(field){
+          const requirement = field.dataset.serviceRequired;
+          if(!requirement) return true;
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          if(!serviceKey) return false;
+          return requirement.split(',').includes(serviceKey);
+        }
+
+        function hasAllRequired(){
+          return requiredFields.every(field => {
+            if(!fieldIsRelevant(field)) return true;
+            const value = field.value ? field.value.trim() : '';
+            if(field.type === 'email'){
+              return value !== '' && value.includes('@');
+            }
+            return value !== '';
+          });
+        }
+
+        function resetServiceGroup(group){
+          const hiddenInputs = Array.from(group.querySelectorAll('input[type="hidden"]'));
+          hiddenInputs.forEach(input => {
+            input.value = '';
+            input.dataset.label = '';
+          });
+          const buttons = Array.from(group.querySelectorAll('[data-target-input]'));
+          buttons.forEach(btn => {
+            btn.classList.remove('active');
+            btn.setAttribute('aria-pressed', 'false');
+          });
+        }
+
+        function updateServiceDetails(serviceKey){
+          if(!serviceDetailsWrapper) return;
+          let activeCount = 0;
+          detailGroups.forEach(group => {
+            const services = (group.dataset.serviceDetail || '').split(',');
+            const match = serviceKey && services.includes(serviceKey);
+            group.classList.toggle('active', !!match);
+            group.setAttribute('aria-hidden', match ? 'false' : 'true');
+            if(match){
+              activeCount += 1;
+            } else {
+              resetServiceGroup(group);
+            }
+          });
+          serviceDetailsWrapper.classList.toggle('visible', activeCount > 0);
+          serviceDetailsWrapper.setAttribute('aria-hidden', activeCount > 0 ? 'false' : 'true');
+        }
+
+        function selectionInfo(input){
+          if(!input || !input.value) return null;
+          return {
+            value: input.value,
+            label: input.dataset.label || input.value
+          };
+        }
+
+        function calculateTotals(){
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          const sqftKey = sqftInput ? sqftInput.value : '';
+          if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
+            return { ready: false, base: 0, detail: 0, total: 0, selections: {}, serviceLabel: '', sqftLabel: '' };
+          }
+
+          const base = basePricing[serviceKey][sqftKey] || 0;
+          let detailAdjustment = 0;
+          const selections = {};
+
+          if(serviceKey === 'home'){
+            const roomsField = form.querySelector('input[name="home-rooms"]');
+            const bathsField = form.querySelector('input[name="home-bathrooms"]');
+            const petsField = form.querySelector('input[name="home-pets"]');
+
+            const roomsInfo = selectionInfo(roomsField);
+            const bathsInfo = selectionInfo(bathsField);
+            const petsInfo = selectionInfo(petsField);
+
+            if(roomsInfo){
+              detailAdjustment += detailPricing.home.rooms[roomsInfo.value] || 0;
+              selections.homeRooms = roomsInfo;
+            }
+            if(bathsInfo){
+              detailAdjustment += detailPricing.home.bathrooms[bathsInfo.value] || 0;
+              selections.homeBathrooms = bathsInfo;
+            }
+            if(petsInfo){
+              detailAdjustment += detailPricing.home.pets[petsInfo.value] || 0;
+              selections.homePets = petsInfo;
+            }
+          }
+
+          if(serviceKey === 'office'){
+            const officesField = form.querySelector('input[name="office-offices"]');
+            const officeBathsField = form.querySelector('input[name="office-bathrooms"]');
+
+            const officesInfo = selectionInfo(officesField);
+            const officeBathsInfo = selectionInfo(officeBathsField);
+
+            if(officesInfo){
+              detailAdjustment += detailPricing.office.offices[officesInfo.value] || 0;
+              selections.officeOffices = officesInfo;
+            }
+            if(officeBathsInfo){
+              detailAdjustment += detailPricing.office.bathrooms[officeBathsInfo.value] || 0;
+              selections.officeBathrooms = officeBathsInfo;
+            }
+          }
+
+          return {
+            ready: true,
+            base,
+            detail: detailAdjustment,
+            total: base + detailAdjustment,
+            selections,
+            serviceLabel: serviceInput?.dataset.label || serviceKey,
+            sqftLabel: sqftInput?.dataset.label || sqftKey
+          };
+        }
+
+        function formatCurrency(value){
+          if(!value) return '—';
+          return `$${Math.round(value)}`;
+        }
+
+        function updateTotals(){
+          const totals = calculateTotals();
+
+          if(basePriceEl){ basePriceEl.textContent = totals.ready ? formatCurrency(totals.base) : '—'; }
+          if(totalPriceEl){ totalPriceEl.textContent = totals.ready ? formatCurrency(totals.total) : '—'; }
+
+          if(detailRow && detailPriceEl){
+            if(totals.ready && totals.detail > 0){
+              detailRow.hidden = false;
+              detailPriceEl.textContent = `+$${Math.round(totals.detail)}`;
+            } else {
+              detailRow.hidden = true;
+              detailPriceEl.textContent = '—';
+            }
+          }
+
+          const ready = totals.ready && hasAllRequired();
+          form.classList.toggle('quote-ready', ready);
+          if(seePriceBtn){ seePriceBtn.disabled = !ready; }
+
+          return totals;
+        }
+
+        pillControls.forEach(control => {
+          const targetName = control.dataset.targetInput;
+          if(!targetName) return;
+          const hiddenInput = form.querySelector(`input[name="${targetName}"]`);
+          if(!hiddenInput) return;
+
+          control.setAttribute('aria-pressed', 'false');
+
+          control.addEventListener('click', () => {
+            const group = control.closest('[role="radiogroup"]') || control.parentElement;
+            if(group){
+              Array.from(group.querySelectorAll('[data-target-input="' + targetName + '"]')).forEach(btn => {
+                const active = btn === control;
+                btn.classList.toggle('active', active);
+                btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+              });
+            }
+
+            hiddenInput.value = control.dataset.value || '';
+            hiddenInput.dataset.label = control.dataset.label || hiddenInput.value;
+            hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
+            updateServiceDetails(serviceInput ? serviceInput.value : '');
+            updateTotals();
+          });
+        });
+
+        requiredFields.forEach(field => {
+          const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
+          field.addEventListener(eventName, updateTotals);
+        });
+
+        if(serviceInput){
+          serviceInput.addEventListener('change', () => {
+            updateServiceDetails(serviceInput.value);
+            updateTotals();
+          });
+        }
+
+        if(sqftInput){
+          sqftInput.addEventListener('change', updateTotals);
+        }
+
+        if(seePriceBtn){
+          seePriceBtn.addEventListener('click', () => {
+            if(seePriceBtn.disabled) return;
+            const totals = updateTotals();
+            if(!totals.ready) return;
+
+            const mode = form.dataset.quoteMode || 'redirect';
+            if(mode !== 'redirect') return;
+
+            const redirectTarget = form.dataset.redirect || 'book.html';
+            const url = new URL(redirectTarget, window.location.origin);
+            const params = url.searchParams;
+
+            const serviceValue = serviceInput ? serviceInput.value : '';
+            if(serviceValue){
+              params.set('service', serviceValue);
+              if(totals.serviceLabel){ params.set('serviceLabel', totals.serviceLabel); }
+            }
+
+            const sqftValue = sqftInput ? sqftInput.value : '';
+            if(sqftValue){
+              params.set('sqft', sqftValue);
+              if(totals.sqftLabel){ params.set('sqftLabel', totals.sqftLabel); }
+            }
+
+            params.set('basePrice', totals.base.toFixed(2));
+            params.set('detailPrice', totals.detail.toFixed(2));
+            params.set('total', totals.total.toFixed(2));
+
+            const firstName = form.querySelector('input[name="first-name"]');
+            if(firstName && firstName.value.trim()){
+              params.set('firstName', firstName.value.trim());
+            }
+
+            const email = form.querySelector('input[name="email"]');
+            if(email && email.value.trim()){
+              params.set('email', email.value.trim());
+            }
+
+            Object.entries(totals.selections || {}).forEach(([key, info]) => {
+              if(info.value){ params.set(key, info.value); }
+              if(info.label){ params.set(`${key}Label`, info.label); }
+            });
+
+            const anchor = form.dataset.redirectAnchor;
+            const finalUrl = anchor ? `${url.toString()}#${anchor}` : url.toString();
+            window.location.href = finalUrl;
+          });
+        }
+
+        updateServiceDetails(serviceInput ? serviceInput.value : '');
+        updateTotals();
+      }
+    })();
+  </script>
+
   <script>
     (function(){
       const form = document.getElementById('bookingForm');
-      const steps = Array.from(document.querySelectorAll('.step'));
-      const stepper = document.getElementById('stepper').children;
-      const reviewList = document.getElementById('reviewList');
-      let current = 0;
+      if(!form) return;
 
+      const steps = Array.from(form.querySelectorAll('.step'));
+      const stepper = Array.from(document.getElementById('stepper').children || []);
+      const reviewList = document.getElementById('reviewList');
+      const successEl = document.getElementById('bookingSuccess');
+      const layoutEl = document.getElementById('bookingLayout');
+
+      const summaryBaseEl = document.getElementById('summary-base-price');
+      const summaryDetailEl = document.getElementById('summary-detail-price');
+      const summaryDetailRow = document.getElementById('summary-detail-row');
+      const summaryExtrasEl = document.getElementById('summary-extras-price');
+      const summaryExtrasRow = document.getElementById('summary-extras-row');
+      const summaryDiscountEl = document.getElementById('summary-discount-price');
+      const summaryDiscountRow = document.getElementById('summary-discount-row');
+      const summaryDepositEl = document.getElementById('summary-deposit-price');
+      const summaryDepositRow = document.getElementById('summary-deposit-row');
+      const summaryBalanceEl = document.getElementById('summary-balance-price');
+      const summaryBalanceRow = document.getElementById('summary-balance-row');
+      const summaryTotalEl = document.getElementById('summary-total-price');
+      const summaryNoteEl = document.getElementById('summary-frequency-note');
+      const summaryDetailList = document.getElementById('summary-detail-list');
+      const addonEmptyMessage = document.getElementById('addon-empty-message');
+
+      const hiddenServiceKey = document.getElementById('input-service-key');
+      const hiddenServiceLabel = document.getElementById('input-service-label');
+      const hiddenSqftLabel = document.getElementById('input-sqft-label');
+      const hiddenDetailSummary = document.getElementById('input-detail-summary');
+      const hiddenBasePrice = document.getElementById('input-base-price');
+      const hiddenDetailPrice = document.getElementById('input-detail-price');
+      const hiddenAddonsPrice = document.getElementById('input-addons-price');
+      const hiddenDiscountPrice = document.getElementById('input-discount-price');
+      const hiddenDepositPrice = document.getElementById('input-deposit-price');
+      const hiddenBalancePrice = document.getElementById('input-balance-price');
+      const hiddenTotalPrice = document.getElementById('input-total-price');
+      const hiddenSelectedAddons = document.getElementById('input-selected-addons');
+      const hiddenPackage = document.getElementById('input-package');
+      const originField = document.getElementById('input-origin');
+
+      const depositText = document.getElementById('deposit-due-text');
+      const balanceText = document.getElementById('balance-due-text');
+
+      const frequencyInputs = Array.from(form.querySelectorAll('input[name="frequency"]'));
+      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
+      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+
+      const DEPOSIT_RATE = 0.5;
+
+      const params = new URLSearchParams(window.location.search);
+      const serviceKey = params.get('service') || '';
+      const serviceLabel = params.get('serviceLabel') || '';
+      const sqftKey = params.get('sqft') || '';
+      const sqftLabel = params.get('sqftLabel') || '';
+      const basePrice = Number(params.get('basePrice') || params.get('total') || 0);
+      const detailPrice = Number(params.get('detailPrice') || 0);
+      const totalBase = basePrice + detailPrice;
+
+      const detailSelections = [];
+      function pushDetail(label, value){
+        if(value){ detailSelections.push(label + ': ' + value); }
+      }
+      pushDetail('Service', serviceLabel || serviceKey);
+      pushDetail('Square Footage', sqftLabel || sqftKey);
+      pushDetail('Rooms', params.get('homeRoomsLabel'));
+      pushDetail('Bathrooms', params.get('homeBathroomsLabel'));
+      pushDetail('Pets', params.get('homePetsLabel'));
+      pushDetail('Offices', params.get('officeOfficesLabel'));
+      pushDetail('Office Bathrooms', params.get('officeBathroomsLabel'));
+
+      hiddenServiceKey.value = serviceKey;
+      hiddenServiceLabel.value = serviceLabel;
+      hiddenSqftLabel.value = sqftLabel;
+      hiddenDetailSummary.value = detailSelections.join(' | ');
+      hiddenBasePrice.value = basePrice.toFixed(2);
+      hiddenDetailPrice.value = detailPrice.toFixed(2);
+      hiddenPackage.value = serviceLabel || serviceKey;
+
+      if(originField){
+        originField.value = serviceKey ? 'instant-quote' : 'book-page';
+      }
+
+      const sqftInput = form.querySelector('input[name="sqft"]');
+      if(sqftInput && sqftKey){
+        const avg = (() => {
+          if(sqftKey.includes('-')){
+            const parts = sqftKey.split('-').map(p => parseInt(p, 10));
+            if(parts.length === 2 && parts.every(n => !Number.isNaN(n))){
+              return Math.round((parts[0] + parts[1]) / 2);
+            }
+          }
+          return '';
+        })();
+        if(avg) sqftInput.value = avg;
+      }
+
+      const nameField = form.querySelector('input[name="name"]');
+      const emailField = form.querySelector('input[name="email"]');
+      const quoteName = params.get('firstName');
+      const quoteEmail = params.get('email');
+      if(nameField && quoteName) nameField.value = quoteName.trim();
+      if(emailField && quoteEmail) emailField.value = quoteEmail.trim();
+
+      function formatCurrency(value){
+        if(!value) return '—';
+        return `$${Math.round(value).toString()}`;
+      }
+
+      function updateDetailList(){
+        summaryDetailList.innerHTML = '';
+        if(!detailSelections.length){
+          const li = document.createElement('li');
+          li.className = 'summary-placeholder';
+          li.textContent = 'Your base package selections will appear here once you start an instant quote.';
+          summaryDetailList.appendChild(li);
+          return;
+        }
+        detailSelections.forEach(item => {
+          const [label, val] = item.split(':');
+          const li = document.createElement('li');
+          li.innerHTML = `<strong>${label.trim()}:</strong> ${val ? val.trim() : ''}`;
+          summaryDetailList.appendChild(li);
+        });
+      }
+      updateDetailList();
+
+      function updateAddonVisibility(){
+        let visibleGroups = 0;
+        addonGroups.forEach(group => {
+          const services = (group.dataset.serviceGroup || '').split(',');
+          const active = serviceKey && services.includes(serviceKey);
+          group.classList.toggle('active', active);
+          if(active) visibleGroups += 1;
+        });
+        if(addonEmptyMessage){ addonEmptyMessage.hidden = visibleGroups !== 0; }
+      }
+      updateAddonVisibility();
+
+      const extrasState = [];
+      function computeExtras(){
+        extrasState.length = 0;
+        addonPills.forEach(pill => {
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+          if(!pill.classList.contains('active')) return;
+          const qtyInput = pill.querySelector('.addon-qty');
+          const qty = qtyInput ? Math.max(Number(qtyInput.value) || 1, Number(qtyInput.min) || 1) : 1;
+          const price = Number(pill.dataset.price || 0);
+          const name = pill.querySelector('.addon-name')?.textContent.trim() || pill.dataset.addon || 'Addon';
+          extrasState.push({ name, qty, price });
+        });
+        return extrasState;
+      }
+
+      function buildExtrasLabel(){
+        if(!extrasState.length) return '';
+        return extrasState.map(item => `${item.name} ×${item.qty}`).join(', ');
+      }
+
+      function selectedFrequency(){
+        return frequencyInputs.find(input => input.checked) || null;
+      }
+
+      function updateSummary(){
+        const extras = computeExtras();
+        const extrasTotal = extras.reduce((sum, item) => sum + item.price * item.qty, 0);
+        const freqInput = selectedFrequency();
+        const discountRate = freqInput ? Number(freqInput.dataset.discount || 0) : 0;
+        const subtotal = totalBase + extrasTotal;
+        const discount = subtotal * discountRate;
+        const finalTotal = subtotal - discount;
+        const depositDue = finalTotal > 0 ? finalTotal * DEPOSIT_RATE : 0;
+        const balanceDue = finalTotal > 0 ? Math.max(finalTotal - depositDue, 0) : 0;
+
+        summaryBaseEl.textContent = formatCurrency(basePrice);
+
+        if(detailPrice > 0){
+          summaryDetailRow.hidden = false;
+          summaryDetailEl.textContent = `+$${Math.round(detailPrice)}`;
+        } else {
+          summaryDetailRow.hidden = true;
+          summaryDetailEl.textContent = '—';
+        }
+
+        if(extrasTotal > 0){
+          summaryExtrasRow.hidden = false;
+          summaryExtrasEl.textContent = `+$${Math.round(extrasTotal)}`;
+        } else {
+          summaryExtrasRow.hidden = true;
+          summaryExtrasEl.textContent = '—';
+        }
+
+        if(discount > 0){
+          summaryDiscountRow.hidden = false;
+          summaryDiscountEl.textContent = `−$${Math.round(discount)}`;
+        } else {
+          summaryDiscountRow.hidden = true;
+          summaryDiscountEl.textContent = '—';
+        }
+
+        if(summaryDepositRow && summaryDepositEl){
+          if(depositDue > 0){
+            summaryDepositRow.hidden = false;
+            summaryDepositEl.textContent = `$${Math.round(depositDue)}`;
+          } else {
+            summaryDepositRow.hidden = true;
+            summaryDepositEl.textContent = '—';
+          }
+        }
+
+        if(summaryBalanceRow && summaryBalanceEl){
+          if(balanceDue > 0){
+            summaryBalanceRow.hidden = false;
+            summaryBalanceEl.textContent = `$${Math.round(balanceDue)}`;
+          } else {
+            summaryBalanceRow.hidden = true;
+            summaryBalanceEl.textContent = '—';
+          }
+        }
+
+        if(depositText){ depositText.textContent = depositDue > 0 ? `$${Math.round(depositDue)}` : '—'; }
+        if(balanceText){ balanceText.textContent = balanceDue > 0 ? `$${Math.round(balanceDue)}` : '—'; }
+
+        summaryTotalEl.textContent = finalTotal ? formatCurrency(finalTotal) : '—';
+
+        if(summaryNoteEl){
+          if(totalBase <= 0){
+            summaryNoteEl.textContent = 'Start with an instant quote to unlock pricing.';
+          } else if(freqInput){
+            const freqLabelMap = {
+              weekly: 'Weekly (25% off)',
+              biweekly: 'Bi-Weekly (20% off)',
+              triweekly: 'Tri-Weekly (15% off)',
+              monthly: 'Monthly (10% off)',
+              biannual: 'Biannual (5% off)',
+              onetime: 'One-time'
+            };
+            summaryNoteEl.textContent = `Includes ${freqLabelMap[freqInput.value] || 'your chosen frequency'} pricing.`;
+          } else {
+            summaryNoteEl.textContent = 'Choose a frequency to see recurring savings.';
+          }
+        }
+
+        if(hiddenAddonsPrice) hiddenAddonsPrice.value = extrasTotal.toFixed(2);
+        if(hiddenDiscountPrice) hiddenDiscountPrice.value = discount.toFixed(2);
+        if(hiddenDepositPrice) hiddenDepositPrice.value = depositDue.toFixed(2);
+        if(hiddenBalancePrice) hiddenBalancePrice.value = balanceDue.toFixed(2);
+        if(hiddenTotalPrice) hiddenTotalPrice.value = finalTotal.toFixed(2);
+        if(hiddenSelectedAddons) hiddenSelectedAddons.value = buildExtrasLabel();
+      }
+
+      addonPills.forEach(pill => {
+        const qtyInput = pill.querySelector('.addon-qty');
+        if(qtyInput){
+          qtyInput.disabled = true;
+        }
+
+        pill.addEventListener('click', (event) => {
+          if(event.target === qtyInput) return;
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+
+          pill.classList.toggle('active');
+          const active = pill.classList.contains('active');
+          pill.setAttribute('aria-pressed', active ? 'true' : 'false');
+          if(qtyInput){
+            qtyInput.disabled = !active;
+            if(active && (!qtyInput.value || Number(qtyInput.value) < Number(qtyInput.min || 1))){
+              qtyInput.value = qtyInput.min || 1;
+            }
+          }
+          updateSummary();
+        });
+
+        pill.addEventListener('keydown', evt => {
+          if(evt.key === 'Enter' || evt.key === ' '){
+            evt.preventDefault();
+            pill.click();
+          }
+        });
+
+        pill.setAttribute('tabindex', '0');
+        pill.setAttribute('role', 'button');
+        pill.setAttribute('aria-pressed', 'false');
+
+        if(qtyInput){
+          qtyInput.addEventListener('input', () => {
+            if(!pill.classList.contains('active')) return;
+            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min || 1)){
+              qtyInput.value = qtyInput.min || 1;
+            }
+            updateSummary();
+          });
+        }
+      });
+
+      frequencyInputs.forEach(input => {
+        input.addEventListener('change', updateSummary);
+      });
+
+      let current = 0;
       function showStep(i){
-        steps.forEach((s, idx)=>{ s.hidden = idx !== i; });
-        Array.from(stepper).forEach((li, idx)=>{
-          li.classList.toggle('active', idx === i);
-          li.classList.toggle('done', idx < i);
+        steps.forEach((step, idx) => { step.hidden = idx !== i; });
+        stepper.forEach((item, idx) => {
+          item.classList.toggle('active', idx === i);
+          item.classList.toggle('done', idx < i);
         });
         current = i;
-        if (i === 4) buildReview(); // step index 4 = "Step 5"
         window.scrollTo({ top: 0, behavior: 'smooth' });
+        if(i === steps.length - 1){
+          buildReview();
+        }
       }
 
-      document.addEventListener('click', (e)=>{
-        if(e.target.matches('.next')){
-          const vis = steps[current];
-          const req = vis.querySelectorAll('[required]');
-          for (const el of req){ if(!el.value){ el.focus(); return; } }
-          showStep(Math.min(current+1, steps.length-1));
+      document.addEventListener('click', (event) => {
+        if(event.target.matches('.next')){
+          const visible = steps[current];
+          const required = Array.from(visible.querySelectorAll('[required]'));
+          for(const field of required){
+            if(!field.value){
+              field.focus();
+              if(field.reportValidity){ field.reportValidity(); }
+              return;
+            }
+          }
+          showStep(Math.min(current + 1, steps.length - 1));
         }
-        if(e.target.matches('.back')){
-          showStep(Math.max(current-1, 0));
+        if(event.target.matches('.back')){
+          showStep(Math.max(current - 1, 0));
         }
       });
 
-      form.addEventListener('submit', (e)=>{
-        e.preventDefault();
-        // Let Formspree submit normally:
-        form.submit();
-        // If you prefer the inline success card instead, uncomment below:
-        // form.hidden = true;
-        // document.getElementById('bookingSuccess').hidden = false;
-      });
-
-      // package descriptions toggle
-      const pkg = document.getElementById('package');
-      function updatePkg(){
-        const blocks = {
-          industrial: document.getElementById('pkg-industrial'),
-          office: document.getElementById('pkg-office'),
-          specialty: document.getElementById('pkg-specialty')
-        };
-        Object.values(blocks).forEach(b=> b.hidden = true);
-        if (blocks[pkg.value]) blocks[pkg.value].hidden = false;
-      }
-      if(pkg){ pkg.addEventListener('change', updatePkg); }
-
-      // Build the review summary
       function buildReview(){
+        if(!reviewList) return;
         const fd = new FormData(form);
         const freqMap = {
           weekly: 'Weekly (25% off)',
@@ -531,215 +1489,116 @@
           biannual: 'Biannual (5% off)',
           onetime: 'One-time'
         };
-        const pkgMap = {
-          industrial: '🏭 Industrial & Warehouse Care',
-          office: '🖥️ Office & Corporate Cleaning',
-          specialty: '🪟 Specialty Facility Services'
+        const paymentMap = {
+          'paypal': 'PayPal',
+          'google-pay': 'Google Pay',
+          'debit': 'Direct Debit / Card on File'
         };
 
         const rows = [
+          ['Service', hiddenServiceLabel.value || '—'],
+          ['Square Footage', hiddenSqftLabel.value || fd.get('sqft') || '—'],
+          ['Details', hiddenDetailSummary.value || '—'],
+          ['Frequency', freqMap[fd.get('frequency')] || '—'],
+          ['Add-ons', hiddenSelectedAddons.value || 'None'],
+          ['Base Package', hiddenBasePrice.value ? `$${Math.round(Number(hiddenBasePrice.value))}` : '—'],
+          ['Service Details', hiddenDetailPrice.value ? `$${Math.round(Number(hiddenDetailPrice.value))}` : '—'],
+          ['Add-on Total', hiddenAddonsPrice.value ? `$${Math.round(Number(hiddenAddonsPrice.value))}` : '—'],
+          ['Frequency Savings', hiddenDiscountPrice.value && Number(hiddenDiscountPrice.value) ? `-$${Math.round(Number(hiddenDiscountPrice.value))}` : '—'],
+          ['Deposit Due Today', hiddenDepositPrice.value && Number(hiddenDepositPrice.value) ? `$${Math.round(Number(hiddenDepositPrice.value))}` : '—'],
+          ['Balance at Service', hiddenBalancePrice.value && Number(hiddenBalancePrice.value) ? `$${Math.round(Number(hiddenBalancePrice.value))}` : '—'],
+          ['Estimated Visit Total', hiddenTotalPrice.value && Number(hiddenTotalPrice.value) ? `$${Math.round(Number(hiddenTotalPrice.value))}` : '—'],
+          ['Payment Method', paymentMap[fd.get('payment_method')] || '—'],
           ['Business', fd.get('business') || '—'],
           ['Address', [fd.get('address'), fd.get('city'), fd.get('postal')].filter(Boolean).join(', ') || '—'],
           ['Preferred Date', fd.get('date') || '—'],
           ['Preferred Time', fd.get('time') || '—'],
-          ['Approx. Sq Ft', fd.get('sqft') || '—'],
-          ['Frequency', freqMap[fd.get('frequency')] || '—'],
-          ['Package', pkgMap[fd.get('package')] || '—'],
           ['Full Name', fd.get('name') || '—'],
           ['Email', fd.get('email') || '—'],
           ['Phone', fd.get('phone') || '—'],
-          ['Notes', (fd.get('notes') || '—')]
+          ['Notes', fd.get('notes') || '—']
         ];
 
-        reviewList.innerHTML = rows.map(([k,v])=> `<dt>${k}</dt><dd>${String(v).replace(/</g,'&lt;')}</dd>`).join('');
+        reviewList.innerHTML = rows.map(([label, value]) => `<dt>${label}</dt><dd>${String(value)}</dd>`).join('');
       }
 
-      // init
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const submitBtn = form.querySelector('.submit');
+        const allButtons = form.querySelectorAll('button');
+        allButtons.forEach(btn => btn.disabled = true);
+        if(submitBtn) submitBtn.textContent = 'Sending…';
+
+        const fd = new FormData(form);
+        if(!fd.get('_subject')){
+          fd.append('_subject', 'New Booking Request — Dufferin Deep Clean');
+        }
+
+        const freqMapShort = {
+          weekly: 'Weekly (25%)',
+          biweekly: 'Bi-Weekly (20%)',
+          triweekly: 'Tri-Weekly (15%)',
+          monthly: 'Monthly (10%)',
+          biannual: 'Biannual (5%)',
+          onetime: 'One-time'
+        };
+        const paymentMapShort = {
+          'paypal': 'PayPal',
+          'google-pay': 'Google Pay',
+          'debit': 'Direct Debit / Card on File'
+        };
+
+        const pricingSummary = [
+          `Service: ${hiddenServiceLabel.value || serviceKey || '—'}`,
+          `Square Footage: ${hiddenSqftLabel.value || fd.get('sqft') || '—'}`,
+          `Details: ${hiddenDetailSummary.value || '—'}`,
+          `Frequency: ${freqMapShort[fd.get('frequency')] || '—'}`,
+          `Base Package: ${hiddenBasePrice.value ? `$${Math.round(Number(hiddenBasePrice.value))}` : '—'}`,
+          `Service Details: ${hiddenDetailPrice.value ? `$${Math.round(Number(hiddenDetailPrice.value))}` : '—'}`,
+          `Add-ons: ${hiddenSelectedAddons.value || 'None'}`,
+          `Add-on Total: ${hiddenAddonsPrice.value ? `$${Math.round(Number(hiddenAddonsPrice.value))}` : '—'}`,
+          `Frequency Savings: ${hiddenDiscountPrice.value && Number(hiddenDiscountPrice.value) ? `-$${Math.round(Number(hiddenDiscountPrice.value))}` : '—'}`,
+          `Deposit Due Today: ${hiddenDepositPrice.value && Number(hiddenDepositPrice.value) ? `$${Math.round(Number(hiddenDepositPrice.value))}` : '—'}`,
+          `Balance at Service: ${hiddenBalancePrice.value && Number(hiddenBalancePrice.value) ? `$${Math.round(Number(hiddenBalancePrice.value))}` : '—'}`,
+          `Estimated Visit Total: ${hiddenTotalPrice.value && Number(hiddenTotalPrice.value) ? `$${Math.round(Number(hiddenTotalPrice.value))}` : '—'}`,
+          `Payment Method: ${paymentMapShort[fd.get('payment_method')] || fd.get('payment_method') || '—'}`
+        ].join('\n');
+
+        fd.append('pricing_summary', pricingSummary);
+
+        try {
+          const res = await fetch(form.action, {
+            method: 'POST',
+            body: fd,
+            headers: { Accept: 'application/json' }
+          });
+
+          if(res.ok){
+            form.hidden = true;
+            if(layoutEl) layoutEl.hidden = true;
+            if(successEl) successEl.hidden = false;
+          } else {
+            let message = 'There was a problem sending your booking request. Please try again.';
+            try {
+              const data = await res.json();
+              if(data && data.errors && data.errors.length){
+                message = data.errors.map(err => err.message).join('\n');
+              }
+            } catch(_){}
+            alert(message);
+          }
+        } catch(err){
+          alert('Network error. Please check your connection and try again.');
+        } finally {
+          allButtons.forEach(btn => btn.disabled = false);
+          if(submitBtn) submitBtn.textContent = 'Submit';
+        }
+      });
+
+      updateSummary();
       showStep(0);
     })();
   </script>
-
-  <!-- OPTIONAL: Google Places Autocomplete (shows "Powered by Google" automatically)
-       Replace YOUR_API_KEY_HERE with your Maps JavaScript API key with Places enabled.
-       If you skip this, the form still works—this block is optional. -->
-  <script>
-    (function attachPlaces(){
-      window.initPlaces = function(){
-        if (!window.google || !google.maps || !google.maps.places) return;
-        const addr = document.getElementById('address');
-        if (!addr) return;
-        const ac = new google.maps.places.Autocomplete(addr, {
-          types: ['address'],
-          fields: ['address_components','formatted_address']
-        });
-        ac.addListener('place_changed', () => {
-          const p = ac.getPlace();
-          if (!p || !p.address_components) return;
-          const cityEl = document.getElementById('city');
-          const postalEl = document.getElementById('postal');
-          const comps = p.address_components;
-
-          const get = (type) => (comps.find(c => c.types.includes(type)) || {}).long_name || '';
-          const city = get('locality') || get('postal_town') || get('administrative_area_level_3') || '';
-          const postal = get('postal_code') || '';
-
-          if (city && cityEl) cityEl.value = city;
-          if (postal && postalEl) postalEl.value = postal;
-        });
-      };
-
-      // If developer adds the script later, this still works.
-      // (Do nothing if script isn't present yet.)
-    })();
-  </script>
-  <!-- If you want Places now, uncomment the next line and insert your key:
-  <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY_HERE&libraries=places&callback=initPlaces" async defer></script>
-  -->
 </body>
 </html>
-<!-- BOOKING FORM -->
-<form id="bookingForm"
-      action="https://formspree.io/f/mrblyqpr"
-      method="POST"
-      novalidate>
-
-  <!-- hidden meta sent to Formspree -->
-  <input type="hidden" name="_subject" value="New Booking — DufferinDeepClean">
-  <!-- optional: redirect after success (change URL if you have a thank-you page) -->
-  <input type="hidden" name="_redirect" value="https://dufferindeepclean.ca/thank-you.html">
-  <input type="hidden" name="page" value="book.html">
-
-  <!-- STEP 1 — when & where -->
-  <section class="step" data-step="1">
-    <input name="date" type="date" required>
-    <input name="time" type="time" required>
-    <input name="address" type="text" placeholder="Street address" required>
-    <button type="button" class="next">Next</button>
-  </section>
-
-  <!-- STEP 2 — how often -->
-  <section class="step" data-step="2" hidden>
-    <select name="frequency" required>
-      <option value="">Select frequency</option>
-      <option>One-time</option>
-      <option>Weekly (25% off)</option>
-      <option>Bi-Weekly (20% off)</option>
-      <option>Monthly (10% off)</option>
-      <option>Biannual</option>
-    </select>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 3 — cleaning type -->
-  <section class="step" data-step="3" hidden>
-    <select name="package" required>
-      <option value="">Select a package</option>
-      <option>Specialty Facility Services</option>
-      <option>Office Basic</option>
-      <option>Deep Clean</option>
-    </select>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 4 — your details -->
-  <section class="step" data-step="4" hidden>
-    <input name="full_name" type="text" placeholder="Full name" required>
-    <input name="email" type="email" placeholder="Email" required>
-    <input name="phone" type="tel" placeholder="Phone" required>
-    <textarea name="notes" placeholder="Anything we should know?"></textarea>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 5 — review & confirm -->
-  <section class="step" data-step="5" hidden>
-    <!-- Optional: render a summary here -->
-    <label class="agree">
-      <input type="checkbox" name="agree" required>
-      I agree to the terms and confirm the details are correct.
-    </label>
-
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <!-- IMPORTANT: this must be type="submit" -->
-      <button type="submit" id="submitBtn">Submit</button>
-    </div>
-  </section>
-
-  <!-- inline status messages -->
-  <p id="formStatus" role="status" aria-live="polite" style="display:none;"></p>
-</form>
-
-<script>
-(function() {
-  const steps = [...document.querySelectorAll('.step')];
-  let i = 0;
-  const show = (n) => {
-    steps.forEach((s, idx) => s.hidden = idx !== n);
-    i = n;
-  };
-
-  document.addEventListener('click', (e) => {
-    if (e.target.classList.contains('next')) {
-      const current = steps[i];
-      // simple validation: ensure current step's required inputs are filled
-      const required = current.querySelectorAll('[required]');
-      for (const field of required) {
-        if (!field.checkValidity()) { field.reportValidity(); return; }
-      }
-      show(Math.min(i + 1, steps.length - 1));
-    }
-    if (e.target.classList.contains('back')) show(Math.max(i - 1, 0));
-  });
-
-  // Ajax submit so you can stay on the page and show a message
-  const form = document.getElementById('bookingForm');
-  const status = document.getElementById('formStatus');
-
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault(); // prevent page reload
-
-    // Final validation across the whole form
-    if (!form.checkValidity()) {
-      // report the first invalid input
-      const firstInvalid = form.querySelector(':invalid');
-      if (firstInvalid) firstInvalid.reportValidity();
-      return;
-    }
-
-    const data = new FormData(form);
-    try {
-      const resp = await fetch(form.action, {
-        method: 'POST',
-        body: data,
-        headers: { 'Accept': 'application/json' }
-      });
-
-      if (resp.ok) {
-        status.style.display = 'block';
-        status.textContent = 'Thanks! Your booking request was sent. We’ll email you shortly.';
-        form.reset();
-        show(0); // go back to step 1
-      } else {
-        const err = await resp.json().catch(() => ({}));
-        throw new Error(err.errors?.map(e => e.message).join(', ') || 'Submission failed.');
-      }
-    } catch (err) {
-      status.style.display = 'block';
-      status.textContent = 'Sorry, we could not submit the form. Please try again or email us.';
-      console.error(err);
-    }
-  });
-
-  // start on step 1
-  show(0);
-})();
-</script>

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
       <a href="#home">Home</a>
       <a href="#services">Services</a>
       <a href="#about">About Us</a>
-      <a href="book.html" class="quote-btn">Book Online</a>
+      <a href="book.html#start" class="quote-btn">Book Online</a>
     </nav>
   </header>
 
@@ -170,11 +170,6 @@
   <!-- HERO -->
   <section id="home" class="split-screen">
     <div class="text-side">
-      <h1 class="headline">
-        <span>We</span> <span>Scrub</span> <span>You</span> <span>Shine</span>
-        <img src="cleanerguy.png" alt="Cleaner" class="headline-image" />
-      </h1>
-
       <div class="rotator-card" id="service-rotator">
         <div class="rotator-window" aria-live="polite">
           <div class="rotator-line active" data-title="Residential Homes">
@@ -205,7 +200,7 @@
             <p>Answer a few quick questions to unlock a tailored estimate for your space.</p>
           </div>
 
-          <form id="instant-quote" class="quote-form" novalidate>
+          <form id="instant-quote" class="quote-form" data-quote-mode="redirect" data-redirect="book.html" data-redirect-anchor="start" novalidate>
             <div class="quote-grid">
               <label class="field" for="quote-first-name">
                 <span class="field-label">First Name</span>
@@ -217,168 +212,116 @@
                 <input id="quote-email" name="email" type="email" placeholder="you@example.com" autocomplete="email" data-required>
               </label>
 
-              <label class="field" for="quote-service">
-                <span class="field-label">Type of Cleaning Service</span>
-                <select id="quote-service" name="service" data-required>
-                  <option value="" disabled selected>Select a service</option>
-                  <option value="home">Home General Cleaning</option>
-                  <option value="commercial">Factory / Commercial / Industrial Cleaning</option>
-                  <option value="office">Office Workspace Cleaning</option>
-                </select>
+              <label class="field field-inline" for="quote-service">
+                <span class="field-label">Type of Service</span>
+                <div class="select-wrap">
+                  <select id="quote-service" name="service" data-required>
+                    <option value="" disabled selected>Select a service</option>
+                    <option value="home">Home General Cleaning</option>
+                    <option value="commercial">Factory / Commercial / Industrial Cleaning</option>
+                    <option value="office">Office Workspace Cleaning</option>
+                  </select>
+                </div>
               </label>
 
-              <label class="field" for="quote-square-footage">
+              <label class="field field-inline" for="quote-sqft">
                 <span class="field-label">Square Footage</span>
-                <select id="quote-square-footage" name="square-footage" data-required>
-                  <option value="" disabled selected>Select the range</option>
-                  <option value="1000-1500">1,000 – 1,500 sq ft</option>
-                  <option value="1500-2000">1,500 – 2,000 sq ft</option>
-                  <option value="2000-2500">2,000 – 2,500 sq ft</option>
-                  <option value="2500-3000">2,500 – 3,000 sq ft</option>
-                  <option value="3000-3500">3,000 – 3,500 sq ft</option>
-                  <option value="3500-4000">3,500 – 4,000 sq ft</option>
-                </select>
+                <div class="select-wrap">
+                  <select id="quote-sqft" name="square-footage" data-required>
+                    <option value="" disabled selected>Select an approximate size</option>
+                    <option value="1000-1500">1,000 – 1,500 sq ft</option>
+                    <option value="1500-2000">1,500 – 2,000 sq ft</option>
+                    <option value="2000-2500">2,000 – 2,500 sq ft</option>
+                    <option value="2500-3000">2,500 – 3,000 sq ft</option>
+                    <option value="3000-3500">3,000 – 3,500 sq ft</option>
+                    <option value="3500-4000">3,500 – 4,000 sq ft</option>
+                  </select>
+                </div>
               </label>
             </div>
 
             <div class="quote-summary" aria-live="polite">
               <div class="quote-summary-line">
-                <span>Base Estimate</span>
-                <strong id="quote-base-price">—</strong>
+                <span>Base Package</span>
+                <strong data-quote-base>—</strong>
+              </div>
+              <div class="quote-summary-line" data-quote-detail-row hidden>
+                <span>Service Details</span>
+                <strong data-quote-detail>—</strong>
               </div>
               <div class="quote-summary-line total">
-                <span>Total with Customizations</span>
-                <strong id="quote-total-price">—</strong>
+                <span>Estimated Visit Total</span>
+                <strong data-quote-total>—</strong>
               </div>
             </div>
 
-            <div id="quote-customize" class="quote-customize" aria-hidden="true">
-              <div class="customize-heading" role="status">Customize your cleaning</div>
-
-              <div class="addon-groups">
-                <div class="addon-group" data-service-group="home">
-                  <p class="addon-group-title">Home &amp; Residential Extras</p>
-                  <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
-                    <span class="addon-icon">✨</span>
-                    <span class="addon-name">Deep Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
-                    <span class="addon-icon">🚚</span>
-                    <span class="addon-name">Move In/Out Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
-                    <span class="addon-icon">🛠️</span>
-                    <span class="addon-name">Renovation Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
-                    <span class="addon-icon">🎓</span>
-                    <span class="addon-name">Move In/Out Package (Student Property)</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
-                  </div>
-                  <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
-                    <span class="addon-icon">🏠</span>
-                    <span class="addon-name">AirBnB Listing</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
-                  </div>
-                  <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
-                    <span class="addon-icon">🐾</span>
-                    <span class="addon-name">I have Pets</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
-                  </div>
-                  <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
-                    <span class="addon-icon">🧊</span>
-                    <span class="addon-name">Inside Fridge</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
-                  </div>
-                  <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
-                    <span class="addon-icon">🔥</span>
-                    <span class="addon-name">Inside Oven</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
-                  </div>
-                  <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
-                    <span class="addon-icon">🗄️</span>
-                    <span class="addon-name">Inside Cabinets</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
-                  </div>
-                  <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
-                    <span class="addon-icon">🍽️</span>
-                    <span class="addon-name">Additional Kitchen</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
-                  </div>
-                  <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
-                    <span class="addon-icon">🪟</span>
-                    <span class="addon-name">Blinds (per window)</span>
-                    <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
-                  </div>
-                  <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
-                    <span class="addon-icon">🔍</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
-                  </div>
-                  <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
-                    <span class="addon-icon">🔎</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
-                  </div>
-                  <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
-                    <span class="addon-icon">🪟</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
-                  </div>
-                  <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
-                    <span class="addon-icon">🛏️</span>
-                    <span class="addon-name">Change Bed Sheets + Load Laundry</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
-                  </div>
-                  <div class="addon-pill color-crimson" data-addon="Load dishwasher" data-price="10">
-                    <span class="addon-icon">🍽️</span>
-                    <span class="addon-name">Load Dishwasher</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
-                  </div>
-                  <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
-                    <span class="addon-icon">🧴</span>
-                    <span class="addon-name">Sanitization Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
-                  </div>
-                </div>
-
-                <div class="addon-group" data-service-group="commercial,office">
-                  <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
-                  <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
-                    <span class="addon-icon">🧼</span>
-                    <span class="addon-name">Carpet Steam Cleaning Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
-                  </div>
-                  <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
-                    <span class="addon-icon">🧽</span>
-                    <span class="addon-name">Tile and Grout Cleaning Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout Cleaning quantity">
-                  </div>
-                  <div class="addon-pill color-mint" data-addon="Restock Bathroom Supply" data-price="40">
-                    <span class="addon-icon">🧻</span>
-                    <span class="addon-name">Restock Bathroom Supply</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Restock Bathroom Supply quantity">
-                  </div>
-                  <div class="addon-pill color-gold" data-addon="Disinfect Electronics" data-price="45">
-                    <span class="addon-icon">💻</span>
-                    <span class="addon-name">Disinfect Electronics</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Disinfect Electronics quantity">
-                  </div>
-                  <div class="addon-pill color-teal" data-addon="Empty Garbage/Recycling" data-price="18">
-                    <span class="addon-icon">🗑️</span>
-                    <span class="addon-name">Empty Garbage/Recycling</span>
-                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Empty Garbage/Recycling quantity">
-                  </div>
-                  <div class="addon-pill color-lime" data-addon="Water Plants" data-price="15">
-                    <span class="addon-icon">🌿</span>
-                    <span class="addon-name">Water Plants</span>
-                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Water Plants quantity">
+            <div id="service-details" class="service-details" aria-live="polite">
+              <div class="service-detail-group" data-service-detail="home" aria-hidden="true">
+                <p class="service-detail-title">Home Cleaning Details</p>
+                <div class="detail-card-grid">
+                  <label class="detail-card" for="home-rooms">
+                    <span class="detail-card-label">Bedrooms</span>
+                    <div class="select-wrap compact">
+                      <select id="home-rooms" name="home-rooms" data-required data-service-required="home">
+                        <option value="" disabled selected>Select rooms</option>
+                        <option value="1-2">1 – 2 rooms</option>
+                        <option value="3-4">3 – 4 rooms</option>
+                        <option value="5-6">5 – 6 rooms</option>
+                        <option value="7+">7+ rooms</option>
+                      </select>
+                    </div>
+                  </label>
+                  <label class="detail-card" for="home-bathrooms">
+                    <span class="detail-card-label">Bathrooms</span>
+                    <div class="select-wrap compact">
+                      <select id="home-bathrooms" name="home-bathrooms" data-required data-service-required="home">
+                        <option value="" disabled selected>Select bathrooms</option>
+                        <option value="1">1 bathroom</option>
+                        <option value="2">2 bathrooms</option>
+                        <option value="3">3 bathrooms</option>
+                        <option value="4+">4+ bathrooms</option>
+                      </select>
+                    </div>
+                  </label>
+                  <div class="detail-card" data-detail-pets>
+                    <span class="detail-card-label">Pets on site?</span>
+                    <input type="hidden" name="home-pets" data-required data-service-required="home">
+                    <div class="mini-pill-group tight" role="radiogroup" aria-label="Are there pets?">
+                      <button type="button" class="mini-pill" data-target-input="home-pets" data-value="no" data-label="No pets">No</button>
+                      <button type="button" class="mini-pill" data-target-input="home-pets" data-value="yes" data-label="Yes, pets">Yes</button>
+                    </div>
                   </div>
                 </div>
               </div>
+
+              <div class="service-detail-group" data-service-detail="office" aria-hidden="true">
+                <p class="service-detail-title">Office Workspace Details</p>
+                <div class="detail-card-grid">
+                  <div class="detail-card">
+                    <span class="detail-card-label">Number of Offices</span>
+                    <input type="hidden" name="office-offices" data-required data-service-required="office">
+                    <div class="mini-pill-group tight" role="radiogroup" aria-label="Number of offices">
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="1-5" data-label="1 – 5 offices">1–5</button>
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="6-10" data-label="6 – 10 offices">6–10</button>
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="11-20" data-label="11 – 20 offices">11–20</button>
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="21+" data-label="21+ offices">21+</button>
+                    </div>
+                  </div>
+                  <div class="detail-card">
+                    <span class="detail-card-label">Number of Bathrooms</span>
+                    <input type="hidden" name="office-bathrooms" data-required data-service-required="office">
+                    <div class="mini-pill-group tight" role="radiogroup" aria-label="Number of bathrooms">
+                      <button type="button" class="mini-pill" data-target-input="office-bathrooms" data-value="1-2" data-label="1 – 2 bathrooms">1–2</button>
+                      <button type="button" class="mini-pill" data-target-input="office-bathrooms" data-value="3-4" data-label="3 – 4 bathrooms">3–4</button>
+                      <button type="button" class="mini-pill" data-target-input="office-bathrooms" data-value="5+" data-label="5+ bathrooms">5+</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="quote-actions">
+              <button type="button" id="quote-see-price" class="quote-see-price" disabled>See My Price</button>
             </div>
           </form>
         </div>
@@ -466,17 +409,8 @@
   <!-- Quote logic -->
   <script>
     (function(){
-      const form = document.getElementById('instant-quote');
-      if(!form) return;
-
-      const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
-      const basePriceEl = document.getElementById('quote-base-price');
-      const totalPriceEl = document.getElementById('quote-total-price');
-      const customizeBlock = document.getElementById('quote-customize');
-      const serviceSelect = document.getElementById('quote-service');
-      const sqftSelect = document.getElementById('quote-square-footage');
-      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
-      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+      const quoteForms = Array.from(document.querySelectorAll('form.quote-form'));
+      if(!quoteForms.length) return;
 
       const basePricing = {
         home: {
@@ -505,146 +439,333 @@
         }
       };
 
-      function hasAllRequired(){
-        return requiredFields.every(field => {
-          if(field.type === 'email'){
-            return field.value.trim() !== '' && field.value.includes('@');
-          }
-          return field.value.trim() !== '';
-        });
-      }
+      const detailPricing = {
+        home: {
+          rooms: { '1-2': 0, '3-4': 25, '5-6': 55, '7+': 85 },
+          bathrooms: { '1': 0, '2': 18, '3': 36, '4+': 54 },
+          pets: { no: 0, yes: 25 }
+        },
+        office: {
+          offices: { '1-5': 0, '6-10': 45, '11-20': 90, '21+': 135 },
+          bathrooms: { '1-2': 0, '3-4': 40, '5+': 70 }
+        }
+      };
 
-      function resetAddons(){
-        addonPills.forEach(pill => {
-          pill.classList.remove('active');
-          const qty = pill.querySelector('.addon-qty');
-          if(qty){
-            qty.value = 1;
-            qty.disabled = true;
-          }
-          pill.setAttribute('aria-pressed', 'false');
-        });
-      }
+      quoteForms.forEach(setupQuoteForm);
 
-      function updateAddonAvailability(serviceKey){
-        addonGroups.forEach(group => {
-          const services = group.dataset.serviceGroup.split(',');
-          const match = services.includes(serviceKey);
-          group.classList.toggle('active', match);
-        });
+      function setupQuoteForm(form){
+        const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
+        const basePriceEl = form.querySelector('[data-quote-base]');
+        const detailRow = form.querySelector('[data-quote-detail-row]');
+        const detailPriceEl = form.querySelector('[data-quote-detail]');
+        const totalPriceEl = form.querySelector('[data-quote-total]');
+        const serviceInput = form.querySelector('[name="service"]');
+        const sqftInput = form.querySelector('[name="square-footage"]');
+        const serviceDetailsWrapper = form.querySelector('.service-details');
+        const detailGroups = serviceDetailsWrapper ? Array.from(serviceDetailsWrapper.querySelectorAll('[data-service-detail]')) : [];
+        const seePriceBtn = form.querySelector('.quote-see-price');
+        const pillControls = Array.from(form.querySelectorAll('[data-target-input]'));
 
-        addonPills.forEach(pill => {
-          const parent = pill.closest('.addon-group');
-          const enabled = parent && parent.classList.contains('active');
-          pill.style.display = enabled ? '' : 'none';
-          if(!enabled){
-            pill.classList.remove('active');
-            const qty = pill.querySelector('.addon-qty');
-            if(qty){
-              qty.value = 1;
-              qty.disabled = true;
-            }
-            pill.setAttribute('aria-pressed', 'false');
-          }
-        });
-      }
-
-      function calculateTotal(){
-        const serviceKey = serviceSelect.value;
-        const sqftKey = sqftSelect.value;
-        if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
-          basePriceEl.textContent = '—';
-          totalPriceEl.textContent = '—';
-          return;
+        function fieldIsRelevant(field){
+          const requirement = field.dataset.serviceRequired;
+          if(!requirement) return true;
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          if(!serviceKey) return false;
+          return requirement.split(',').includes(serviceKey);
         }
 
-        const base = basePricing[serviceKey][sqftKey] || 0;
-        let total = base;
-
-        addonPills.forEach(pill => {
-          if(!pill.classList.contains('active')) return;
-          const parent = pill.closest('.addon-group');
-          if(!parent || !parent.classList.contains('active')) return;
-
-          const price = Number(pill.dataset.price || 0);
-          const qtyInput = pill.querySelector('.addon-qty');
-          const qty = qtyInput ? Math.max(1, Number(qtyInput.value) || 1) : 1;
-          total += price * qty;
-        });
-
-        basePriceEl.textContent = base ? `$${base.toFixed(0)}` : '—';
-        totalPriceEl.textContent = total ? `$${total.toFixed(0)}` : '—';
-      }
-
-      function toggleCustomize(){
-        const ready = hasAllRequired();
-        customizeBlock.classList.toggle('visible', ready);
-        customizeBlock.setAttribute('aria-hidden', ready ? 'false' : 'true');
-        form.classList.toggle('quote-ready', ready);
-        if(!ready){
-          basePriceEl.textContent = '—';
-          totalPriceEl.textContent = '—';
-          resetAddons();
-        } else {
-          updateAddonAvailability(serviceSelect.value);
-          calculateTotal();
-        }
-      }
-
-      addonPills.forEach(pill => {
-        pill.addEventListener('click', (event) => {
-          if(!customizeBlock.classList.contains('visible')) return;
-          const qtyInput = pill.querySelector('.addon-qty');
-          if(event.target === qtyInput) return;
-
-          pill.classList.toggle('active');
-          if(qtyInput){
-            qtyInput.disabled = !pill.classList.contains('active');
-          }
-          pill.setAttribute('aria-pressed', pill.classList.contains('active') ? 'true' : 'false');
-          calculateTotal();
-        });
-
-        const qtyInput = pill.querySelector('.addon-qty');
-        if(qtyInput){
-          qtyInput.disabled = true;
-          qtyInput.addEventListener('input', () => {
-            if(!pill.classList.contains('active')) return;
-            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min)){
-              qtyInput.value = qtyInput.min;
+        function hasAllRequired(){
+          return requiredFields.every(field => {
+            if(!fieldIsRelevant(field)) return true;
+            const value = field.value ? field.value.trim() : '';
+            if(field.type === 'email'){
+              return value !== '' && value.includes('@');
             }
-            calculateTotal();
+            return value !== '';
           });
         }
 
-        pill.addEventListener('keydown', (evt) => {
-          if(evt.key === 'Enter' || evt.key === ' '){
-            evt.preventDefault();
-            pill.click();
+        function resetServiceGroup(group){
+          const hiddenInputs = Array.from(group.querySelectorAll('input[type="hidden"]'));
+          hiddenInputs.forEach(input => {
+            input.value = '';
+            input.dataset.label = '';
+          });
+          const selects = Array.from(group.querySelectorAll('select'));
+          selects.forEach(select => {
+            select.selectedIndex = 0;
+          });
+          const buttons = Array.from(group.querySelectorAll('[data-target-input]'));
+          buttons.forEach(btn => {
+            btn.classList.remove('active');
+            btn.setAttribute('aria-pressed', 'false');
+          });
+        }
+
+        function updateServiceDetails(serviceKey){
+          if(!serviceDetailsWrapper) return;
+          let activeCount = 0;
+          detailGroups.forEach(group => {
+            const services = (group.dataset.serviceDetail || '').split(',');
+            const match = serviceKey && services.includes(serviceKey);
+            group.classList.toggle('active', !!match);
+            group.setAttribute('aria-hidden', match ? 'false' : 'true');
+            if(match){
+              activeCount += 1;
+            } else {
+              resetServiceGroup(group);
+            }
+          });
+          serviceDetailsWrapper.classList.toggle('visible', activeCount > 0);
+          serviceDetailsWrapper.setAttribute('aria-hidden', activeCount > 0 ? 'false' : 'true');
+        }
+
+        function selectionInfo(input){
+          if(!input || !input.value) return null;
+          return {
+            value: input.value,
+            label: resolveLabel(input)
+          };
+        }
+
+        function resolveLabel(input){
+          if(!input) return '';
+          if(input.tagName === 'SELECT'){
+            const option = input.options[input.selectedIndex];
+            if(option){
+              return option.dataset.label || option.textContent.trim();
+            }
+            return '';
           }
+          if(input.dataset && input.dataset.label){
+            return input.dataset.label;
+          }
+          return input.value || '';
+        }
+
+        function calculateTotals(){
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          const sqftKey = sqftInput ? sqftInput.value : '';
+          if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
+            return { ready: false, base: 0, detail: 0, total: 0, selections: {}, serviceLabel: '', sqftLabel: '' };
+          }
+
+          const base = basePricing[serviceKey][sqftKey] || 0;
+          let detailAdjustment = 0;
+          const selections = {};
+
+          if(serviceKey === 'home'){
+            const roomsField = form.querySelector('[name="home-rooms"]');
+            const bathsField = form.querySelector('[name="home-bathrooms"]');
+            const petsField = form.querySelector('[name="home-pets"]');
+
+            const roomsInfo = selectionInfo(roomsField);
+            const bathsInfo = selectionInfo(bathsField);
+            const petsInfo = selectionInfo(petsField);
+
+            if(roomsInfo){
+              detailAdjustment += detailPricing.home.rooms[roomsInfo.value] || 0;
+              selections.homeRooms = roomsInfo;
+            }
+            if(bathsInfo){
+              detailAdjustment += detailPricing.home.bathrooms[bathsInfo.value] || 0;
+              selections.homeBathrooms = bathsInfo;
+            }
+            if(petsInfo){
+              detailAdjustment += detailPricing.home.pets[petsInfo.value] || 0;
+              selections.homePets = petsInfo;
+            }
+          }
+
+          if(serviceKey === 'office'){
+            const officesField = form.querySelector('[name="office-offices"]');
+            const officeBathsField = form.querySelector('[name="office-bathrooms"]');
+
+            const officesInfo = selectionInfo(officesField);
+            const officeBathsInfo = selectionInfo(officeBathsField);
+
+            if(officesInfo){
+              detailAdjustment += detailPricing.office.offices[officesInfo.value] || 0;
+              selections.officeOffices = officesInfo;
+            }
+            if(officeBathsInfo){
+              detailAdjustment += detailPricing.office.bathrooms[officeBathsInfo.value] || 0;
+              selections.officeBathrooms = officeBathsInfo;
+            }
+          }
+
+          return {
+            ready: true,
+            base,
+            detail: detailAdjustment,
+            total: base + detailAdjustment,
+            selections,
+            serviceLabel: resolveLabel(serviceInput) || serviceKey,
+            sqftLabel: resolveLabel(sqftInput) || sqftKey
+          };
+        }
+
+        function formatCurrency(value){
+          if(!value) return '—';
+          return `$${Math.round(value)}`;
+        }
+
+        function updateTotals(){
+          const totals = calculateTotals();
+
+          if(basePriceEl){ basePriceEl.textContent = totals.ready ? formatCurrency(totals.base) : '—'; }
+          if(totalPriceEl){ totalPriceEl.textContent = totals.ready ? formatCurrency(totals.total) : '—'; }
+
+          if(detailRow && detailPriceEl){
+            if(totals.ready && totals.detail > 0){
+              detailRow.hidden = false;
+              detailPriceEl.textContent = `+$${Math.round(totals.detail)}`;
+            } else {
+              detailRow.hidden = true;
+              detailPriceEl.textContent = '—';
+            }
+          }
+
+          const ready = totals.ready && hasAllRequired();
+          form.classList.toggle('quote-ready', ready);
+          if(seePriceBtn){ seePriceBtn.disabled = !ready; }
+
+          return totals;
+        }
+
+        pillControls.forEach(control => {
+          const targetName = control.dataset.targetInput;
+          if(!targetName) return;
+          const hiddenInput = form.querySelector(`input[name="${targetName}"]`);
+          if(!hiddenInput) return;
+
+          control.setAttribute('aria-pressed', 'false');
+
+          control.addEventListener('click', () => {
+            const group = control.closest('[role="radiogroup"]') || control.parentElement;
+            if(group){
+              Array.from(group.querySelectorAll('[data-target-input="' + targetName + '"]')).forEach(btn => {
+                const active = btn === control;
+                btn.classList.toggle('active', active);
+                btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+              });
+            }
+
+            hiddenInput.value = control.dataset.value || '';
+            hiddenInput.dataset.label = control.dataset.label || hiddenInput.value;
+            hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
+            updateServiceDetails(serviceInput ? serviceInput.value : '');
+            updateTotals();
+          });
         });
-        pill.setAttribute('tabindex', '0');
-        pill.setAttribute('role', 'button');
-        pill.setAttribute('aria-pressed', 'false');
+
+        requiredFields.forEach(field => {
+          const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
+          field.addEventListener(eventName, updateTotals);
+        });
+
+        if(serviceInput){
+          serviceInput.addEventListener('change', () => {
+            updateServiceDetails(serviceInput.value);
+            updateTotals();
+          });
+        }
+
+        if(sqftInput){
+          sqftInput.addEventListener('change', updateTotals);
+        }
+
+        if(seePriceBtn){
+          seePriceBtn.addEventListener('click', () => {
+            if(seePriceBtn.disabled) return;
+            const totals = updateTotals();
+            if(!totals.ready) return;
+
+            const mode = form.dataset.quoteMode || 'redirect';
+            if(mode !== 'redirect') return;
+
+            const redirectTarget = form.dataset.redirect || 'book.html';
+            const url = new URL(redirectTarget, window.location.origin);
+            const params = url.searchParams;
+
+            const serviceValue = serviceInput ? serviceInput.value : '';
+            if(serviceValue){
+              params.set('service', serviceValue);
+              if(totals.serviceLabel){ params.set('serviceLabel', totals.serviceLabel); }
+            }
+
+            const sqftValue = sqftInput ? sqftInput.value : '';
+            if(sqftValue){
+              params.set('sqft', sqftValue);
+              if(totals.sqftLabel){ params.set('sqftLabel', totals.sqftLabel); }
+            }
+
+            params.set('basePrice', totals.base.toFixed(2));
+            params.set('detailPrice', totals.detail.toFixed(2));
+            params.set('total', totals.total.toFixed(2));
+
+            const firstName = form.querySelector('input[name="first-name"]');
+            if(firstName && firstName.value.trim()){
+              params.set('firstName', firstName.value.trim());
+            }
+
+            const email = form.querySelector('input[name="email"]');
+            if(email && email.value.trim()){
+              params.set('email', email.value.trim());
+            }
+
+            Object.entries(totals.selections || {}).forEach(([key, info]) => {
+              if(info.value){ params.set(key, info.value); }
+              if(info.label){ params.set(`${key}Label`, info.label); }
+            });
+
+            const anchor = form.dataset.redirectAnchor;
+            const finalUrl = anchor ? `${url.toString()}#${anchor}` : url.toString();
+            window.location.href = finalUrl;
+          });
+        }
+
+        updateServiceDetails(serviceInput ? serviceInput.value : '');
+        updateTotals();
+      }
+    })();
+  </script>
+
+  <script>
+    (function(){
+      const navQuoteLink = document.querySelector('.nav-links .quote-btn');
+      const quoteSection = document.getElementById('quote');
+      if(!navQuoteLink || !quoteSection) return;
+
+      let spotlightTimer = null;
+
+      navQuoteLink.addEventListener('click', (event) => {
+        if(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        if(typeof event.button === 'number' && event.button !== 0) return;
+        event.preventDefault();
+        quoteSection.classList.remove('quote-spotlight');
+        void quoteSection.offsetWidth;
+        quoteSection.classList.add('quote-spotlight');
+        quoteSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+        const focusTarget = quoteSection.querySelector('input, button');
+        if(focusTarget){
+          try {
+            focusTarget.focus({ preventScroll: true });
+          } catch(_){
+            focusTarget.focus();
+          }
+        }
+
+        if(spotlightTimer){
+          window.clearTimeout(spotlightTimer);
+        }
+
+        spotlightTimer = window.setTimeout(() => {
+          quoteSection.classList.remove('quote-spotlight');
+          spotlightTimer = null;
+        }, 1600);
       });
-
-      requiredFields.forEach(field => {
-        const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
-        field.addEventListener(eventName, toggleCustomize);
-      });
-
-      serviceSelect.addEventListener('change', () => {
-        updateAddonAvailability(serviceSelect.value);
-        calculateTotal();
-      });
-
-      sqftSelect.addEventListener('change', calculateTotal);
-
-      addonPills.forEach(pill => {
-        pill.setAttribute('aria-pressed', 'false');
-      });
-
-      toggleCustomize();
     })();
   </script>
 

--- a/style.css
+++ b/style.css
@@ -177,7 +177,12 @@ h1, h2, h3 {
 }
 
 /* Headline */
-.headline { font-size: 3rem; font-weight: 800; line-height: 1.2; }
+.headline {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1.2;
+  margin-top: clamp(1.75rem, 4vw, 3.5rem);
+}
 .headline span { display: inline-block; animation: fadeIn 1s ease forwards; opacity: 0; }
 .headline span:nth-child(1){animation-delay:.3s}
 .headline span:nth-child(2){animation-delay:.6s}
@@ -209,9 +214,9 @@ h1, h2, h3 {
    QUOTE PANEL
    ========================= */
 .hero-quote {
-  margin-top: clamp(1.8rem, 4vw, 2.8rem);
+  margin-top: clamp(1.4rem, 3vw, 2.1rem);
   width: 100%;
-  max-width: 640px;
+  max-width: 520px;
   display: flex;
   align-self: flex-start;
 }
@@ -219,17 +224,18 @@ h1, h2, h3 {
 .quote-card {
   width: 100%;
   flex: 1;
-  padding: clamp(1.8rem, 3vw, 2.45rem);
-  border-radius: 32px;
-  border: 1.5px solid rgba(0, 212, 255, 0.45);
-  background: linear-gradient(135deg, rgba(8, 19, 30, 0.75), rgba(12, 24, 40, 0.55));
+  padding: clamp(1.1rem, 2.5vw, 1.75rem);
+  border-radius: 22px;
+  border: 1.8px solid rgba(0, 212, 255, 0.55);
+  background: linear-gradient(135deg, rgba(8, 19, 30, 0.82), rgba(10, 26, 38, 0.58));
   box-shadow:
-    0 35px 120px rgba(0, 0, 0, 0.6),
-    0 0 30px rgba(0, 212, 255, 0.25),
-    inset 0 0 35px rgba(0, 212, 255, 0.08);
-  backdrop-filter: blur(16px);
+    0 26px 90px rgba(0, 0, 0, 0.58),
+    0 0 22px rgba(0, 212, 255, 0.22),
+    inset 0 0 28px rgba(0, 212, 255, 0.06);
+  backdrop-filter: blur(14px);
   position: relative;
   overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .quote-card::before {
@@ -237,79 +243,306 @@ h1, h2, h3 {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1.5px solid rgba(0, 212, 255, 0.35);
+  border: 2.2px solid rgba(0, 212, 255, 0.28);
   pointer-events: none;
   box-shadow: 0 0 45px rgba(0, 212, 255, 0.2);
   opacity: 0.6;
 }
 
+.hero-quote.quote-spotlight .quote-card {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 2px rgba(0, 212, 255, 0.65),
+    0 32px 70px rgba(0, 0, 0, 0.6),
+    inset 0 0 32px rgba(0, 212, 255, 0.12);
+}
+
+.hero-quote.quote-spotlight .quote-card::before {
+  animation: quotePulse 1.2s ease-in-out 2;
+}
+
+@keyframes quotePulse {
+  0%, 100% {
+    opacity: 0.6;
+    box-shadow: 0 0 45px rgba(0, 212, 255, 0.2);
+  }
+  50% {
+    opacity: 0.95;
+    box-shadow: 0 0 80px rgba(0, 212, 255, 0.35);
+  }
+}
+
 .quote-card-header {
-  margin-bottom: 1.75rem;
+  margin-bottom: 1.1rem;
 }
 
 .quote-card-header h2 {
-  font-size: clamp(1.9rem, 3vw, 2.55rem);
-  letter-spacing: 0.12em;
+  font-size: clamp(1.32rem, 2.6vw, 1.85rem);
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: #e6f8ff;
-  margin-bottom: 0.75rem;
-  text-shadow: 0 0 22px rgba(0, 212, 255, 0.45);
+  margin-bottom: 0.45rem;
+  text-shadow: 0 0 18px rgba(0, 212, 255, 0.35);
 }
 
 .quote-card-header p {
-  color: rgba(212, 235, 255, 0.78);
-  font-size: 0.98rem;
-  max-width: 32ch;
+  color: rgba(212, 235, 255, 0.75);
+  font-size: 0.86rem;
+  max-width: 30ch;
 }
 
 .quote-form {
   display: flex;
   flex-direction: column;
-  gap: 1.65rem;
+  gap: 1.15rem;
 }
 
 .quote-grid {
   display: grid;
-  gap: 1.2rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.4rem;
+}
+
+.field-inline {
+  gap: 0.3rem;
 }
 
 .field-label {
-  font-size: 0.95rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(173, 214, 255, 0.85);
+  letter-spacing: 0.16em;
+  color: rgba(173, 214, 255, 0.82);
+}
+
+.select-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: rgba(5, 14, 24, 0.75);
+  border: 1px solid rgba(0, 212, 255, 0.28);
+  border-radius: 14px;
+  padding: 0.1rem 0.4rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.select-wrap::after {
+  content: "▾";
+  font-size: 0.65rem;
+  color: rgba(173, 214, 255, 0.8);
+  pointer-events: none;
+  margin-left: 0.3rem;
+}
+
+.select-wrap select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0.45rem 1.4rem 0.45rem 0.35rem;
+  font-size: 0.9rem;
+  color: #ecf5ff;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.select-wrap select option {
+  color: #0b161e;
+  background: #ecf5ff;
+}
+
+.select-wrap select:focus {
+  outline: none;
+}
+
+.select-wrap:focus-within {
+  border-color: rgba(0, 212, 255, 0.55);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.select-wrap.compact {
+  padding: 0.05rem 0.35rem;
+}
+
+.select-wrap.compact select {
+  font-size: 0.82rem;
+  padding: 0.35rem 1.2rem 0.35rem 0.3rem;
 }
 
 .field input,
 .field select {
-  padding: 0.85rem 1rem;
-  border-radius: 16px;
-  border: 1.5px solid rgba(0, 212, 255, 0.25);
-  background: rgba(8, 19, 32, 0.75);
+  padding: 0.65rem 0.85rem;
+  border-radius: 14px;
+  border: 1.2px solid rgba(0, 212, 255, 0.22);
+  background: rgba(8, 19, 32, 0.72);
   color: #f2fbff;
-  font-size: 1rem;
-  box-shadow: inset 0 0 18px rgba(0, 212, 255, 0.06);
+  font-size: 0.92rem;
+  box-shadow: inset 0 0 14px rgba(0, 212, 255, 0.05);
   transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
 .field input:focus,
 .field select:focus {
   outline: none;
-  border-color: rgba(0, 212, 255, 0.65);
-  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  border-color: rgba(0, 212, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
   transform: translateY(-1px);
 }
 
+.mini-pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.mini-pill {
+  appearance: none;
+  border: 1px solid rgba(0, 212, 255, 0.25);
+  background: rgba(6, 16, 26, 0.75);
+  color: #e9faff;
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  min-width: 58px;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.mini-pill:hover,
+.mini-pill:focus-visible {
+  border-color: rgba(0, 212, 255, 0.5);
+  color: #fff;
+  outline: none;
+}
+
+.mini-pill.active {
+  background: linear-gradient(135deg, rgba(0, 212, 255, 0.35), rgba(0, 128, 255, 0.35));
+  border-color: rgba(0, 212, 255, 0.75);
+  color: #0b161e;
+  box-shadow: 0 8px 18px rgba(0, 212, 255, 0.25);
+}
+
+.service-details {
+  margin-top: 0.35rem;
+  border-radius: 18px;
+  border: 1px solid transparent;
+  background: rgba(8, 19, 32, 0.0);
+  box-shadow: none;
+  display: grid;
+  gap: 0.95rem;
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  max-height: 0;
+  padding: 0 1.1rem;
+  overflow: hidden;
+  transition: opacity 0.35s ease, transform 0.35s ease, max-height 0.45s ease, padding 0.35s ease;
+}
+
+.service-details.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  max-height: 420px;
+  padding: 1.05rem 1.1rem 1.15rem;
+  border-color: rgba(0, 212, 255, 0.16);
+  background: rgba(8, 19, 32, 0.5);
+  box-shadow: inset 0 0 18px rgba(0, 212, 255, 0.07);
+}
+
+.service-detail-group {
+  display: none;
+  gap: 0.75rem;
+}
+
+.service-detail-group.active {
+  display: grid;
+  gap: 0.75rem;
+  animation: detailFade 0.35s ease forwards;
+}
+
+@keyframes detailFade {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.service-detail-title {
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(173, 214, 255, 0.72);
+}
+
+.detail-card-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.detail-card {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.65rem;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 212, 255, 0.18);
+  background: radial-gradient(circle at top, rgba(10, 26, 38, 0.75), rgba(6, 14, 26, 0.82));
+  box-shadow: inset 0 0 12px rgba(0, 212, 255, 0.08);
+  position: relative;
+  overflow: hidden;
+  align-content: start;
+}
+
+.detail-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(0, 212, 255, 0.08), rgba(0, 212, 255, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.detail-card:focus-within::after,
+.detail-card:hover::after {
+  opacity: 1;
+}
+
+.detail-card-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(173, 214, 255, 0.72);
+}
+
+.mini-pill-group.tight {
+  gap: 0.35rem;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.mini-pill-group.tight .mini-pill {
+  min-width: 48px;
+  padding: 0.35rem 0.7rem;
+}
+
 .quote-summary {
-  padding: 1.2rem 1.4rem;
-  border-radius: 24px;
+  padding: 0.95rem 1.05rem;
+  border-radius: 18px;
   background: rgba(10, 22, 34, 0.65);
   border: 1px solid rgba(0, 212, 255, 0.22);
   box-shadow: inset 0 0 22px rgba(0, 212, 255, 0.08);
@@ -317,6 +550,43 @@ h1, h2, h3 {
   gap: 0.85rem;
   opacity: 0.55;
   transition: opacity 0.35s ease;
+}
+
+.quote-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.quote-see-price {
+  appearance: none;
+  border-radius: 14px;
+  border: 1.5px solid rgba(0, 212, 255, 0.35);
+  background: linear-gradient(180deg, rgba(0, 212, 255, 0.25), rgba(0, 212, 255, 0.1));
+  color: #f2fbff;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.65rem 1.4rem;
+  font-size: 0.86rem;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, transform 0.25s ease, color 0.25s ease;
+}
+
+.quote-see-price:not(:disabled):hover,
+.quote-see-price:not(:disabled):focus-visible {
+  border-color: rgba(0, 212, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  background: linear-gradient(180deg, rgba(0, 212, 255, 0.45), rgba(0, 212, 255, 0.2));
+  transform: translateY(-1px);
+}
+
+.quote-see-price:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  background: rgba(8, 19, 32, 0.45);
+  border-color: rgba(0, 212, 255, 0.18);
+  color: rgba(214, 238, 255, 0.6);
 }
 
 .quote-form.quote-ready .quote-summary {
@@ -327,20 +597,170 @@ h1, h2, h3 {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   color: rgba(214, 238, 255, 0.85);
 }
 
 .quote-summary-line strong {
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   letter-spacing: 0.05em;
   color: #f7fdff;
   text-shadow: 0 0 12px rgba(0, 212, 255, 0.35);
 }
 
 .quote-summary-line.total {
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
+}
+
+@media (min-width: 1024px) {
+  .split-screen {
+    gap: clamp(1rem, 2vw, 1.6rem);
+  }
+
+  .split-screen .text-side {
+    padding: clamp(2.2rem, 4vw, 3.1rem);
+    gap: 1.1rem;
+  }
+
+  .rotator-card {
+    padding: 0.95rem 1.2rem;
+    max-width: 420px;
+    border-radius: 20px;
+  }
+
+  .rotator-title {
+    font-size: 0.82rem;
+    letter-spacing: 0.12em;
+  }
+
+  .rotator-text {
+    font-size: 0.98rem;
+    line-height: 1.5;
+  }
+
+  .rotator-dots {
+    gap: 0.35rem;
+  }
+
+  .rotator-dots .dot {
+    width: 7px;
+    height: 7px;
+  }
+
+  .split-screen .hero-quote {
+    max-width: 380px;
+  }
+
+  .split-screen .hero-quote .quote-card {
+    padding: 0.95rem 1.05rem;
+    border-radius: 18px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.45),
+      0 0 14px rgba(0, 212, 255, 0.18),
+      inset 0 0 16px rgba(0, 212, 255, 0.05);
+  }
+
+  .split-screen .hero-quote .quote-card-header {
+    margin-bottom: 0.85rem;
+  }
+
+  .split-screen .hero-quote .quote-card-header h2 {
+    font-size: 1.42rem;
+    letter-spacing: 0.14em;
+  }
+
+  .split-screen .hero-quote .quote-card-header p {
+    font-size: 0.75rem;
+    max-width: 26ch;
+  }
+
+  .split-screen .hero-quote .quote-form {
+    gap: 0.9rem;
+  }
+
+  .split-screen .hero-quote .quote-grid {
+    gap: 0.55rem;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .split-screen .hero-quote .field {
+    gap: 0.3rem;
+  }
+
+  .split-screen .hero-quote .field-label {
+    font-size: 0.68rem;
+    letter-spacing: 0.16em;
+  }
+
+  .split-screen .hero-quote .field input,
+  .split-screen .hero-quote .field select {
+    padding: 0.5rem 0.65rem;
+    border-radius: 10px;
+    font-size: 0.8rem;
+  }
+
+  .split-screen .hero-quote .mini-pill-group {
+    gap: 0.35rem;
+  }
+
+  .split-screen .hero-quote .mini-pill {
+    padding: 0.32rem 0.55rem;
+    min-height: 28px;
+    min-width: 52px;
+    font-size: 0.68rem;
+  }
+
+  .split-screen .hero-quote .service-details {
+    border-radius: 14px;
+  }
+
+  .split-screen .hero-quote .service-details.visible {
+    gap: 0.7rem;
+    padding: 0.8rem 0.85rem 0.95rem;
+  }
+
+  .split-screen .hero-quote .service-detail-group {
+    gap: 0.55rem;
+  }
+
+  .split-screen .hero-quote .service-detail-title {
+    font-size: 0.68rem;
+  }
+
+  .split-screen .hero-quote .detail-card-grid {
+    gap: 0.45rem;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  }
+
+  .split-screen .hero-quote .detail-card {
+    padding: 0.55rem;
+  }
+
+  .split-screen .hero-quote .quote-summary {
+    padding: 0.65rem 0.75rem;
+    border-radius: 14px;
+    gap: 0.55rem;
+  }
+
+  .split-screen .hero-quote .quote-summary-line {
+    font-size: 0.82rem;
+  }
+
+  .split-screen .hero-quote .quote-summary-line strong {
+    font-size: 0.92rem;
+  }
+
+  .split-screen .hero-quote .quote-actions {
+    margin-top: 0.65rem;
+  }
+
+  .split-screen .hero-quote .quote-see-price {
+    padding: 0.55rem 1.15rem;
+    border-radius: 12px;
+    font-size: 0.76rem;
+    letter-spacing: 0.1em;
+  }
 }
 
 .quote-customize {
@@ -391,29 +811,35 @@ h1, h2, h3 {
   display: none;
 }
 
+
 .addon-group.active {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
 }
 
 .addon-pill {
+  position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  justify-content: center;
+  gap: 0.35rem;
+  width: 80px;
+  min-height: 80px;
+  padding: 0.45rem 0.5rem;
   border-radius: 999px;
   background: rgba(16, 32, 48, 0.6);
   border: 1.5px solid rgba(0, 212, 255, 0.18);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.38);
   cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  text-align: center;
 }
 
 .addon-pill:hover {
-  transform: scale(1.06);
-  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.45);
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
 }
 
 .addon-pill.active {
@@ -421,25 +847,28 @@ h1, h2, h3 {
   box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.25), 0 22px 40px rgba(0, 0, 0, 0.55);
 }
 
+
 .addon-icon {
-  font-size: 1.35rem;
+  font-size: 1.4rem;
   flex-shrink: 0;
 }
 
 .addon-name {
-  flex: 1;
-  font-size: 1rem;
+  font-size: 0.68rem;
+  line-height: 1.1;
   color: rgba(226, 245, 255, 0.9);
+  word-break: break-word;
 }
 
 .addon-qty {
-  width: 3.5rem;
-  padding: 0.4rem 0.5rem;
-  border-radius: 14px;
+  width: 100%;
+  max-width: 62px;
+  padding: 0.25rem 0.4rem;
+  border-radius: 999px;
   border: 1.5px solid rgba(0, 212, 255, 0.35);
   background: rgba(6, 20, 32, 0.75);
   color: #f2fbff;
-  font-size: 1rem;
+  font-size: 0.75rem;
   transition: border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
@@ -448,6 +877,7 @@ h1, h2, h3 {
   border-color: rgba(0, 212, 255, 0.7);
   box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
 }
+
 
 .addon-pill:not(.active) .addon-qty {
   opacity: 0.4;
@@ -489,20 +919,22 @@ h1, h2, h3 {
   }
 
   .addon-group.active {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(68px, 1fr));
   }
 
   .addon-pill {
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    width: 68px;
+    min-height: 68px;
+    padding: 0.35rem;
+    gap: 0.28rem;
   }
 
   .addon-name {
-    flex-basis: 100%;
+    font-size: 0.62rem;
   }
 
   .addon-qty {
-    width: 100%;
+    font-size: 0.7rem;
   }
 }
 .services-btn-home:hover { background:#00d4ff; color:#000; transform: translateY(-2px); box-shadow: 0 8px 20px rgba(0,212,255,.3); }


### PR DESCRIPTION
## Summary
- convert the hero quote to compact dropdown selectors with animated detail cards and a wider bordered outline
- ensure service details animate within the existing space and send readable labels downstream for pricing
- remove the book.html headliner quote block and switch the stepper highlight to the requested pink accent while keeping the payment wall intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e183836ec88320a011a1b38925ff6f