### PR TITLE
Widen frequency tiles and remove payment setup copy

### DIFF
--- a/book.html
+++ b/book.html
@@ -6,28 +6,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Book Online — DufferinDeepClean</title>
 
-  <!-- Fonts (match index + About Us script) -->
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;800&family=Great+Vibes&display=swap" rel="stylesheet" />
-
-  <!-- Site CSS (keep your existing file) -->
   <link rel="stylesheet" href="style.css" />
+  <script src="nav-cart.js" defer></script>
 
-  <!-- Page-specific styles to: 
-       1) match index animated background (slightly darker here),
-       2) unify logo font + animation,
-       3) keep your booking UI exactly as-is otherwise. -->
   <style>
-    /* ===== Animated seamless background (same as index, slightly darker) ===== */
     :root{
-      /* Use the same seamless tile image you use on index */
-      --bg-tile: url('backgroundbook.png');    /* or cleaning-pattern.png if that’s your tile */
+      --bg-tile: url('backgroundbook.png');
       --tile-w: 1536px;
       --tile-h: 1024px;
       --tile-scale: 0.90;
       --tile-w-size: calc(var(--tile-w) * var(--tile-scale));
       --tile-h-size: calc(var(--tile-h) * var(--tile-scale));
-
-      /* Darker overlay than index (index ≈ 0.40/0.66/0.80) */
       --overlay-a: rgba(0,0,0,0.52);
       --overlay-b: rgba(0,0,0,0.78);
       --overlay-c: rgba(0,0,0,0.90);
@@ -40,7 +30,6 @@
       background: transparent !important;
     }
 
-    /* Animated tile layer (under content) */
     body::after{
       content:"";
       position: fixed; inset: 0; z-index: 0; pointer-events: none;
@@ -55,22 +44,21 @@
       to   { background-position: var(--tile-w-size) var(--tile-h-size); }
     }
 
-    /* Darker readability overlay for booking page */
     body::before{
       content:"";
       position: fixed; inset: 0; z-index: 1; pointer-events: none;
-      background: radial-gradient(1200px 600px at 50% -10%,
-                  var(--overlay-a), var(--overlay-b) 60%, var(--overlay-c));
+      background: radial-gradient(1200px 600px at 50% -10%, var(--overlay-a), var(--overlay-b) 60%, var(--overlay-c));
     }
 
-    /* Ensure all content sits above background layers */
     .navbar, main, section, footer { position: relative; z-index: 2; }
 
-    /* ===== NAV: transparent like index, unified logo font + left→right unveil ===== */
     .navbar{
-      display:flex; justify-content:space-between; align-items:center;
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      gap: clamp(1rem, 2vw, 2.4rem);
       padding: 14px 22px;
-      background: rgba(0,0,0,0.20);           /* transparent header over the moving bg */
+      background: rgba(0,0,0,0.20);
       backdrop-filter: blur(6px);
       border-bottom: 1px solid rgba(255,255,255,0.08);
       position: sticky; top: 0; z-index: 1000;
@@ -78,7 +66,7 @@
     .logo{ display:flex; align-items:center; gap:.55rem; }
     .logo .soap{ font-size: 2.2rem; transform: translateY(2px); }
     .logo .logo-text{
-      font-family: 'Great Vibes', cursive !important;  /* match About Us */
+      font-family: 'Great Vibes', cursive !important;
       font-size: 2.8rem; line-height: 1; letter-spacing: .4px; color:#fff;
       position:relative; display:inline-block;
       clip-path: inset(0 100% 0 0); opacity:0;
@@ -94,16 +82,32 @@
       animation: logoSweep 1.1s ease forwards .25s;
     }
 
-    /* Nav links match site look */
     .nav-links a{
-      font-family: 'Bebas Neue', sans-serif;
-      letter-spacing: .5px;
-      color: #cfe0ee; text-decoration:none; margin-left:18px;
+      font-family: 'Inter', sans-serif;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-size: 0.95rem;
+      color: #e9f7ff;
+      text-decoration:none;
+      margin-left:18px;
       transition: color .25s ease;
     }
     .nav-links a:hover{ color:#fff; }
 
-    /* ===== Booking page layout (your original UI, unchanged) ===== */
+    .nav-actions{
+      display:flex;
+      align-items:center;
+      gap: clamp(0.6rem, 1.2vw, 1.1rem);
+    }
+
+    .nav-cart{
+      background: rgba(0,0,0,0.35);
+      border: 1px solid rgba(0,212,255,0.32);
+      padding: 0.5em 1em;
+      color: #f1fbff;
+    }
+
     .booking{
       max-width: 1100px; margin: 0 auto;
       padding: clamp(20px, 4vw, 48px);
@@ -126,10 +130,11 @@
       border-radius: 16px;
       box-shadow: 0 10px 30px rgba(0,0,0,0.35);
       backdrop-filter: blur(6px);
+      text-transform: lowercase;
     }
     .stepper li{
       padding: 14px 12px; text-align: center; border-radius: 12px;
-      font-weight: 600; text-transform: lowercase; color: #b6c2cf;
+      font-weight: 600; color: #b6c2cf;
       border: 1px dashed rgba(255,255,255,0.12);
       transition: transform .2s ease, background .2s ease, color .2s ease, border-color .2s ease;
     }
@@ -139,26 +144,200 @@
       background: linear-gradient(180deg, rgba(0,208,132,0.12), rgba(0,208,132,0.05));
     }
     .stepper li.active{
-      color: #111; 
-      background: linear-gradient(180deg, #ffd166, #ffb703);
-      border-color: rgba(255,183,3,0.65);
+      color: #fff;
+      background: linear-gradient(180deg, #ff90dc, #ff4fc3);
+      border-color: rgba(255, 128, 210, 0.7);
+      box-shadow: 0 12px 28px rgba(255, 110, 205, 0.25);
       transform: translateY(-1px);
     }
 
     .booking-card{
       margin: 18px auto 0; width: min(100%, 1050px);
-      background: rgba(10, 12, 16, 0.72);     /* slightly darker card to match page darkness */
+      background: rgba(10, 12, 16, 0.72);
       border: 1px solid rgba(255,255,255,0.08);
       border-radius: 20px;
       box-shadow: 0 20px 50px rgba(0,0,0,0.45);
       backdrop-filter: blur(8px);
       overflow: hidden;
     }
-    .booking-form, .booking-success{ padding: clamp(16px, 3vw, 28px); }
+    .booking-layout{
+      display: flex;
+      flex-direction: column;
+      gap: clamp(18px, 3vw, 32px);
+      padding: clamp(18px, 3vw, 32px);
+    }
+    .booking-form{
+      padding: 0;
+    }
+
+    .form-columns{
+      display: grid;
+      gap: clamp(18px, 3vw, 32px);
+    }
+
+    .form-steps{
+      display: grid;
+      gap: clamp(18px, 3vw, 28px);
+      min-width: 0;
+    }
+    .booking-success{ padding: clamp(16px, 3vw, 28px); }
 
     fieldset{ border: none; margin: 0; padding: 0; }
     legend{ font-weight: 800; font-size: 1.2rem; margin-bottom: 14px; }
     .muted{ color: #b6c2cf; }
+
+    .cart-summary{
+      background: rgba(7, 18, 32, 0.72);
+      border: 1px solid rgba(0, 212, 255, 0.18);
+      border-radius: 18px;
+      padding: clamp(12px, 1.8vw, 18px);
+      box-shadow: 0 12px 30px rgba(0,0,0,0.35);
+      display: grid;
+      gap: clamp(10px, 1.6vw, 16px);
+      width: 100%;
+      max-width: 250px;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+    }
+
+    .cart-summary.is-added{
+      border-color: rgba(0, 212, 255, 0.45);
+      box-shadow: 0 20px 46px rgba(0,0,0,0.45), 0 0 0 2px rgba(0, 212, 255, 0.12);
+      opacity: 0.96;
+    }
+
+    .cart-summary-flight{
+      animation: cartSummaryFlight 0.65s ease;
+    }
+
+    .cart-summary header{
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .cart-summary img{
+      width: 64px;
+      height: 64px;
+      object-fit: cover;
+      border-radius: 14px;
+      border: 1px solid rgba(255,255,255,0.12);
+      background: rgba(255,255,255,0.1);
+      box-shadow: 0 10px 24px rgba(0,0,0,0.35);
+    }
+
+    .cart-summary-title{
+      margin: 0;
+      font-family: "Bebas Neue", system-ui, sans-serif;
+      font-size: clamp(20px, 3vw, 26px);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .cart-summary-subtitle{
+      color: #b6c2cf;
+      font-size: 0.85rem;
+      margin: 2px 0 0;
+    }
+
+    .cart-details{
+      font-size: 0.85rem;
+      color: #99b3cc;
+      line-height: 1.45;
+    }
+
+    .cart-pricing{
+      border-radius: 16px;
+      border: 1px solid rgba(0, 212, 255, 0.2);
+      background: rgba(4, 18, 28, 0.65);
+      padding: 12px;
+      display: grid;
+      gap: 6px;
+    }
+
+    .cart-line{
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.9rem;
+      color: #d7e7f8;
+    }
+
+    .cart-line.total{
+      font-weight: 700;
+      font-size: 1rem;
+    }
+
+    .cart-line.deposit{
+      color: #00d084;
+      font-weight: 600;
+    }
+
+    .cart-line.balance{
+      color: #fbd38d;
+    }
+
+    .cart-divider{
+      height: 1px;
+      background: linear-gradient(90deg, rgba(0,212,255,0), rgba(0,212,255,0.45), rgba(0,212,255,0));
+      margin: 2px 0;
+    }
+
+    @keyframes cartSummaryFlight{
+      0% { transform: translateY(0); opacity: 1; }
+      40% { transform: translateY(-6px); opacity: 0.92; }
+      100% { transform: translateY(0); opacity: 1; }
+    }
+
+    .cart-btn{
+      justify-content: center;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-weight: 700;
+      background: linear-gradient(180deg, #ff8edb, #ff4fc3);
+      border-color: rgba(255, 112, 210, 0.75);
+      color: #fff;
+      box-shadow: 0 12px 32px rgba(255, 110, 205, 0.35);
+    }
+
+    .cart-btn:disabled{
+      background: linear-gradient(180deg, rgba(255, 142, 219, 0.28), rgba(255, 79, 195, 0.2));
+      border-color: rgba(255, 112, 210, 0.35);
+      color: rgba(255,255,255,0.68);
+      box-shadow: none;
+    }
+
+    .cart-btn.is-added{
+      background: linear-gradient(180deg, #ff9ee4, #ff64d0);
+      border-color: rgba(255, 140, 220, 0.85);
+      color: #fff;
+    }
+
+    .cart-status{
+      min-height: 1em;
+      font-size: 0.9rem;
+      color: #9ad4ff;
+    }
+
+    .cart-status.error{ color: #ff6b9a; }
+
+    .payment-policy{
+      border-radius: 14px;
+      border: 1px dashed rgba(255,255,255,0.18);
+      padding: 14px;
+      font-size: 0.9rem;
+      color: #d7e7f8;
+      background: rgba(255,255,255,0.02);
+    }
+
+    .payment-policy h3{
+      margin-top: 0;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: #ffe0f7;
+    }
+
+    .payment-policy p{ margin: 0; }
 
     .grid-2{ display: grid; gap: 14px; grid-template-columns: 1fr; }
     .grid-2 .wide{ grid-column: 1 / -1; }
@@ -175,14 +354,15 @@
       background: rgba(255,255,255,0.08);
     }
 
-    .plans{ display:grid; gap:12px; grid-template-columns: 1fr; }
-    @media (min-width: 840px){ .plans{ grid-template-columns: repeat(3, 1fr); } }
+    .plans{ display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    @media (min-width: 840px){ .plans{ grid-template-columns: repeat(3, minmax(220px, 1fr)); } }
     .plan{ display:block; }
     .plan input{ display:none; }
     .plan-card{
-      border: 1px solid rgba(255,255,255,0.08); border-radius: 14px; padding: 14px;
+      border: 1px solid rgba(255,255,255,0.08); border-radius: 14px; padding: clamp(16px, 2.6vw, 24px);
       background: rgba(255,255,255,0.04);
       transition: transform .2s ease, border-color .2s ease, background .2s ease;
+      min-height: 140px;
     }
     .plan input:checked + .plan-card{
       border-color: rgba(0,208,132,0.6);
@@ -193,7 +373,59 @@
     .plan-discount{ color: #00d084; font-weight: 700; }
     .plan-note{ color: #b6c2cf; font-size: .9rem; }
 
+    .pricing-recap{
+      margin-top: 12px;
+      border-radius: 16px;
+      border: 1px solid rgba(0,212,255,0.18);
+      background: rgba(4, 18, 28, 0.55);
+      padding: clamp(14px, 2.4vw, 20px);
+      display: grid;
+      gap: 0.6rem;
+    }
+    .pricing-recap-title{
+      margin: 0;
+      font-size: 0.9rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: rgba(214, 238, 255, 0.8);
+    }
+    .pricing-breakdown{
+      display: grid;
+      gap: 0.45rem;
+    }
+    .pricing-line{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    .pricing-label{
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgba(214, 238, 255, 0.65);
+    }
+    .pricing-value{
+      font-weight: 700;
+      color: #f5fbff;
+    }
+    .pricing-line.total{
+      margin-top: 0.4rem;
+      padding-top: 0.5rem;
+      border-top: 1px solid rgba(255,255,255,0.08);
+    }
+    .pricing-line.total .pricing-value{
+      font-size: 1.05rem;
+    }
+    .pricing-recap-details{
+      margin: 0;
+      font-size: 0.78rem;
+      line-height: 1.5;
+      color: rgba(214, 238, 255, 0.7);
+    }
+
     .actions{ margin-top: 18px; display:flex; gap:10px; justify-content:flex-end; flex-wrap: wrap; }
+    .step[data-step="1"] .actions{ justify-content:flex-start; }
     .btn{
       appearance: none; border: 1px solid rgba(255,255,255,0.08); color: #0b0d10;
       background: linear-gradient(180deg, #4cc3ff, #00e0a4);
@@ -204,13 +436,6 @@
     }
     .btn:hover{ filter: brightness(1.05); }
 
-    .package-desc{
-      border: 1px dashed rgba(255,255,255,0.2);
-      border-radius: 12px;
-      padding: 12px;
-      background: rgba(255,255,255,0.03);
-    }
-
     .review{
       display:grid; gap:10px;
       border: 1px solid rgba(255,255,255,0.08);
@@ -220,10 +445,26 @@
     }
     .review dt{ font-weight: 700; color: #b6c2cf; }
     .review dd{ margin: 0 0 10px; }
+
+    .addon-empty{ color: rgba(214, 238, 255, 0.7); font-size: 0.95rem; }
+
+    @media (min-width: 900px){
+      .form-columns{
+        grid-template-columns: minmax(0, 1fr) minmax(240px, 280px);
+        align-items: start;
+      }
+      .cart-summary{
+        position: sticky;
+        top: 24px;
+        max-height: calc(100vh - 80px);
+        overflow: auto;
+      }
+    }
+
+    
   </style>
 </head>
-<body>
-  <!-- NAV -->
+<body data-paypal-client-id="" data-paypal-currency="CAD">
   <header class="navbar">
     <div class="logo">
       <span class="soap">🧼</span>
@@ -233,71 +474,93 @@
       <a href="index.html#home">Home</a>
       <a href="index.html#services">Services</a>
       <a href="about.html">About Us</a>
+      <a href="book.html#start" class="quote-btn">Book Online</a>
     </nav>
+    <div class="nav-actions">
+      <button class="nav-cart" type="button" data-cart-toggle aria-haspopup="dialog" aria-controls="navCartPopover" aria-expanded="false">
+        <span class="nav-cart-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path d="M4.5 4h-2a.5.5 0 0 1 0-1h2.8a1 1 0 0 1 .97.76L6.7 6H21a1 1 0 0 1 .96 1.27l-2 7A1 1 0 0 1 19 15H9.24l-.78 2.34A1 1 0 0 1 7.52 18H4.5a.5.5 0 0 1 0-1h2.55l3.2-9.6L9.8 6H4.78a1 1 0 0 1-.95-.68L4.5 4Zm4.28 3-2.4 7.2H19.1l1.71-6H8.78ZM9 19.75a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Zm9.5 0a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Z" fill="currentColor"/>
+          </svg>
+        </span>
+        <span class="nav-cart-label">Cart</span>
+        <span class="nav-cart-count" data-cart-count hidden>0</span>
+      </button>
+    </div>
   </header>
+  <aside class="nav-cart-popover" id="navCartPopover" role="dialog" aria-modal="false" aria-label="Cart summary" hidden>
+    <div class="nav-cart-popover-inner">
+      <button type="button" class="cart-popover-close" data-cart-close aria-label="Close cart">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <header class="cart-popover-header">
+        <img data-cart-popover-image alt="Cart package preview" loading="lazy" />
+        <div>
+          <p class="cart-popover-title" data-popover-service>Your cart is empty</p>
+          <p class="cart-popover-subtitle" data-popover-frequency>Build a package to see pricing here.</p>
+        </div>
+      </header>
+      <p class="cart-popover-status" data-popover-status hidden></p>
+      <p class="cart-popover-empty" data-popover-empty>Use “Book Online” to customise your cleaning package.</p>
+      <dl class="cart-popover-details" data-popover-details hidden></dl>
+      <div class="cart-popover-totals" data-popover-totals hidden>
+        <div><span>Visit total</span><span data-popover-total>—</span></div>
+        <div><span>Deposit (50%)</span><span data-popover-deposit>—</span></div>
+        <div><span>Balance</span><span data-popover-balance>—</span></div>
+      </div>
+      <div class="cart-popover-payments" data-popover-payments hidden>
+        <div id="nav-paypal-buttons" data-paypal-container="nav"></div>
+        <p class="cart-popover-paypal-status" id="nav-paypal-status" role="status" aria-live="polite"></p>
+        <button type="button" class="btn cart-popover-google" data-google-pay-button disabled>Google Pay (coming soon)</button>
+      </div>
+    </div>
+  </aside>
 
-  <section class="booking">
+  <section class="booking" id="start">
     <h1 class="booking-title">book online</h1>
 
-    <!-- Long, centered step rectangle -->
     <div class="stepper-wrap">
       <ol class="stepper" id="stepper">
-        <li class="active">1. when &amp; where</li>
-        <li>2. how often</li>
-        <li>3. cleaning type</li>
-        <li>4. your details</li>
+        <li class="active">1. frequency</li>
+        <li>2. add extras</li>
+        <li>3. your details</li>
+        <li>4. when &amp; where</li>
         <li>5. review &amp; confirm</li>
       </ol>
     </div>
 
-    <!-- Application card -->
     <div class="booking-card">
-      <form id="bookingForm" class="booking-form" action="https://formspree.io/f/mrblyqpr" method="POST">
-        <!-- STEP 1: When & Where -->
-        <fieldset class="step" data-step="1">
-          <legend>When &amp; Where</legend>
-          <div class="grid-2">
-            <label>
-              Business name (optional)
-              <input type="text" name="business" placeholder="ACME Distribution" />
-            </label>
-            <label>
-              Address
-              <input id="address" type="text" name="address" placeholder="123 Main St" required autocomplete="address-line1" />
-            </label>
-            <label>
-              City
-              <input id="city" type="text" name="city" placeholder="Mono" required autocomplete="address-level2" />
-            </label>
-            <label>
-              Postal Code
-              <input id="postal" type="text" name="postal" placeholder="L9W 1A1" required autocomplete="postal-code" />
-            </label>
-            <label>
-              Preferred date
-              <input type="date" name="date" required />
-            </label>
-            <label>
-              Preferred time
-              <input type="time" name="time" required />
-            </label>
-            <label class="wide">
-              Approx. square footage
-              <input type="number" name="sqft" min="100" step="50" placeholder="e.g., 5,000" required />
-            </label>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn next">Next</button>
-          </div>
-        </fieldset>
+      <div class="booking-layout" id="bookingLayout">
+                <form id="bookingForm" class="booking-form" action="https://formspree.io/f/mrblyqpr" method="POST">
 
-        <!-- STEP 2: How Often -->
-        <fieldset class="step" data-step="2" hidden>
-          <legend>How Often?</legend>
-          <p class="muted">Save on recurring cleanings. Choose a frequency.</p>
+          <input type="hidden" name="service_key" id="input-service-key">
+          <input type="hidden" name="service_label" id="input-service-label">
+          <input type="hidden" name="square_footage_range" id="input-sqft-label">
+          <input type="hidden" name="detail_summary" id="input-detail-summary">
+          <input type="hidden" name="base_package_price" id="input-base-price">
+          <input type="hidden" name="service_detail_price" id="input-detail-price">
+          <input type="hidden" name="addons_price" id="input-addons-price">
+          <input type="hidden" name="frequency_savings" id="input-discount-price">
+          <input type="hidden" name="deposit_due" id="input-deposit-price">
+          <input type="hidden" name="balance_due" id="input-balance-price">
+          <input type="hidden" name="final_visit_total" id="input-total-price">
+          <input type="hidden" name="selected_addons" id="input-selected-addons">
+          <input type="hidden" name="origin_quote" id="input-origin" value="">
+          <input type="hidden" name="package" id="input-package">
+          <input type="hidden" name="paypal_order_id" id="input-paypal-order-id">
+          <input type="hidden" name="paypal_payer_id" id="input-paypal-payer-id">
+          <input type="hidden" name="paypal_capture_id" id="input-paypal-capture-id">
+          <input type="hidden" name="cart_status" id="input-cart-status" value="pending">
+          <input type="hidden" name="name" id="input-full-name" value="">
+
+          <div class="form-columns">
+            <div class="form-steps">
+
+          <fieldset class="step" data-step="1">
+          <legend>Choose your visit frequency</legend>
           <div class="plans">
             <label class="plan">
-              <input type="radio" name="frequency" value="weekly" required />
+              <input type="radio" name="frequency" value="weekly" data-discount="0.25" required />
               <div class="plan-card">
                 <div class="plan-title">Weekly</div>
                 <div class="plan-discount">25% off</div>
@@ -305,7 +568,7 @@
               </div>
             </label>
             <label class="plan">
-              <input type="radio" name="frequency" value="biweekly" />
+              <input type="radio" name="frequency" value="biweekly" data-discount="0.20" />
               <div class="plan-card">
                 <div class="plan-title">Bi-Weekly</div>
                 <div class="plan-discount">20% off</div>
@@ -313,7 +576,7 @@
               </div>
             </label>
             <label class="plan">
-              <input type="radio" name="frequency" value="triweekly" />
+              <input type="radio" name="frequency" value="triweekly" data-discount="0.15" />
               <div class="plan-card">
                 <div class="plan-title">Tri-Weekly</div>
                 <div class="plan-discount">15% off</div>
@@ -321,110 +584,270 @@
               </div>
             </label>
             <label class="plan">
-              <input type="radio" name="frequency" value="monthly" />
+              <input type="radio" name="frequency" value="monthly" data-discount="0.10" />
               <div class="plan-card">
                 <div class="plan-title">Monthly</div>
                 <div class="plan-discount">10% off</div>
-                <div class="plan-note">Routine upkeep</div>
+                <div class="plan-note">Deep refresh once a month</div>
               </div>
             </label>
             <label class="plan">
-              <input type="radio" name="frequency" value="biannual" />
+              <input type="radio" name="frequency" value="biannual" data-discount="0.05" />
               <div class="plan-card">
                 <div class="plan-title">Biannual</div>
                 <div class="plan-discount">5% off</div>
-                <div class="plan-note">Seasonal refresh</div>
+                <div class="plan-note">Seasonal top-to-bottom</div>
               </div>
             </label>
             <label class="plan">
-              <input type="radio" name="frequency" value="onetime" />
+              <input type="radio" name="frequency" value="onetime" data-discount="0" />
               <div class="plan-card">
                 <div class="plan-title">One-time</div>
-                <div class="plan-discount">—</div>
-                <div class="plan-note">Deep clean on demand</div>
+                <div class="plan-discount">Standard rate</div>
+                <div class="plan-note">Perfect for move-ins &amp; projects</div>
               </div>
             </label>
           </div>
           <div class="actions">
-            <button type="button" class="btn back">Back</button>
             <button type="button" class="btn next">Next</button>
           </div>
         </fieldset>
 
-        <!-- STEP 3: Cleaning Type + Packages -->
-        <fieldset class="step" data-step="3" hidden>
-          <legend>What type of cleaning?</legend>
-          <div class="grid-2">
-            <label class="wide">
-              Select a package
-              <select name="package" id="package" required>
-                <option value="" disabled selected>Choose a package…</option>
-                <option value="industrial">🏭 Industrial &amp; Warehouse Care</option>
-                <option value="office">🖥️ Office &amp; Corporate Cleaning</option>
-                <option value="specialty">🪟 Specialty Facility Services</option>
-              </select>
-            </label>
-
-            <!-- Industrial -->
-            <div class="package-desc" id="pkg-industrial" hidden>
-              <h4>🏭 Industrial &amp; Warehouse Care</h4>
-              <p class="muted"><strong>Tagline:</strong> Heavy-duty cleaning for high-demand environments.<br/><strong>Ideal for:</strong> Factories, distribution centers, and large-scale workspaces.</p>
-              <ul>
-                <li>High-dusting and overhead beam cleaning</li>
-                <li>Sweeping, scrubbing, and degreasing of production floors</li>
-                <li>Equipment and machinery wipe-downs</li>
-                <li>Loading dock and storage area cleaning</li>
-                <li>Restroom cleaning and sanitation for high-traffic use</li>
-              </ul>
+        <fieldset class="step" data-step="2" hidden>
+          <legend>Add extra services</legend>
+          <p class="muted">Add speciality tasks for this visit. Select a tile to include it and adjust the quantity if needed.</p>
+          <div class="addon-groups" id="addon-groups">
+            <div class="addon-group" data-service-group="home">
+              <p class="addon-group-title">Home &amp; Residential Extras</p>
+              <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
+                <span class="addon-icon" data-icon="sparkle" aria-hidden="true"></span>
+                <span class="addon-name">Deep Clean Package</span>
+                <div class="addon-stepper" role="group" aria-label="Deep Clean Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Deep Clean Package quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Deep Clean Package quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
+                <span class="addon-icon" data-icon="truck" aria-hidden="true"></span>
+                <span class="addon-name">Move In/Out Clean Package</span>
+                <div class="addon-stepper" role="group" aria-label="Move In/Out Clean Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Move In/Out Clean Package quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Move In/Out Clean Package quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
+                <span class="addon-icon" data-icon="tool" aria-hidden="true"></span>
+                <span class="addon-name">Renovation Clean Package</span>
+                <div class="addon-stepper" role="group" aria-label="Renovation Clean Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Renovation Clean Package quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Renovation Clean Package quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
+                <span class="addon-icon" data-icon="cap" aria-hidden="true"></span>
+                <span class="addon-name">Move In/Out Package (Student Property)</span>
+                <div class="addon-stepper" role="group" aria-label="Move In/Out Package (Student Property) quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Move In/Out Package (Student Property) quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Move In/Out Package (Student Property) quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
+                <span class="addon-icon" data-icon="home" aria-hidden="true"></span>
+                <span class="addon-name">AirBnB Listing</span>
+                <div class="addon-stepper" role="group" aria-label="AirBnB Listing quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease AirBnB Listing quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase AirBnB Listing quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
+                <span class="addon-icon" data-icon="paw" aria-hidden="true"></span>
+                <span class="addon-name">I have Pets</span>
+                <div class="addon-stepper" role="group" aria-label="I have Pets quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease I have Pets quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase I have Pets quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
+                <span class="addon-icon" data-icon="fridge" aria-hidden="true"></span>
+                <span class="addon-name">Inside Fridge</span>
+                <div class="addon-stepper" role="group" aria-label="Inside Fridge quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Inside Fridge quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Inside Fridge quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
+                <span class="addon-icon" data-icon="oven" aria-hidden="true"></span>
+                <span class="addon-name">Inside Oven</span>
+                <div class="addon-stepper" role="group" aria-label="Inside Oven quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Inside Oven quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Inside Oven quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
+                <span class="addon-icon" data-icon="cabinet" aria-hidden="true"></span>
+                <span class="addon-name">Inside Cabinets</span>
+                <div class="addon-stepper" role="group" aria-label="Inside Cabinets quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Inside Cabinets quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Inside Cabinets quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
+                <span class="addon-icon" data-icon="utensils" aria-hidden="true"></span>
+                <span class="addon-name">Additional Kitchen</span>
+                <div class="addon-stepper" role="group" aria-label="Additional Kitchen quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Additional Kitchen quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Additional Kitchen quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
+                <span class="addon-icon" data-icon="blinds" aria-hidden="true"></span>
+                <span class="addon-name">Blinds (per window)</span>
+                <div class="addon-stepper" role="group" aria-label="Blinds (per window) quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Blinds quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Blinds quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
+                <span class="addon-icon" data-icon="window" aria-hidden="true"></span>
+                <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
+                <div class="addon-stepper" role="group" aria-label="Inside Windows with Tracks (up to 6) quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Inside Windows with Tracks (up to 6) quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Inside Windows with Tracks (up to 6) quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
+                <span class="addon-icon" data-icon="window" aria-hidden="true"></span>
+                <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
+                <div class="addon-stepper" role="group" aria-label="Inside Windows with Tracks (up to 12) quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Inside Windows with Tracks (up to 12) quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Inside Windows with Tracks (up to 12) quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
+                <span class="addon-icon" data-icon="window" aria-hidden="true"></span>
+                <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
+                <div class="addon-stepper" role="group" aria-label="Inside Windows with Tracks (up to 24) quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Inside Windows with Tracks (up to 24) quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Inside Windows with Tracks (up to 24) quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
+                <span class="addon-icon" data-icon="bed" aria-hidden="true"></span>
+                <span class="addon-name">Change Bed Sheets + Load Laundry</span>
+                <div class="addon-stepper" role="group" aria-label="Change Bed Sheets + Load Laundry quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Change Bed Sheets quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Change Bed Sheets quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-crimson" data-addon="Load Dishwasher" data-price="10">
+                <span class="addon-icon" data-icon="dish" aria-hidden="true"></span>
+                <span class="addon-name">Load Dishwasher</span>
+                <div class="addon-stepper" role="group" aria-label="Load Dishwasher quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Load Dishwasher quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Load Dishwasher quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
+                <span class="addon-icon" data-icon="spray" aria-hidden="true"></span>
+                <span class="addon-name">Sanitization Package</span>
+                <div class="addon-stepper" role="group" aria-label="Sanitization Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Sanitization Package quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Sanitization Package quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
             </div>
 
-            <!-- Office -->
-            <div class="package-desc" id="pkg-office" hidden>
-              <h4>🖥️ Office &amp; Corporate Cleaning</h4>
-              <p class="muted"><strong>Tagline:</strong> A spotless, professional image for your business.<br/><strong>Ideal for:</strong> Offices, corporate headquarters, and professional buildings.</p>
-              <ul>
-                <li>Daily surface and workstation cleaning</li>
-                <li>Waste removal and recycling service</li>
-                <li>Floor care: vacuuming, mopping, and spot-cleaning carpets</li>
-                <li>Reception and common-area tidying</li>
-                <li>Restroom cleaning and supply replenishment</li>
-              </ul>
-            </div>
-
-            <!-- Specialty -->
-            <div class="package-desc" id="pkg-specialty" hidden>
-              <h4>🪟 Specialty Facility Services</h4>
-              <p class="muted"><strong>Tagline:</strong> Targeted deep-cleaning for the areas that matter most.<br/><strong>Ideal for:</strong> Businesses needing targeted or seasonal deep-cleaning.</p>
-              <ul>
-                <li>Window washing and glass polishing (interior &amp; exterior)</li>
-                <li>Cafeteria / lunchroom cleaning and sanitization</li>
-                <li>Washroom deep-clean and disinfection</li>
-                <li>Touchpoint sanitization (doors, handles, switches)</li>
-                <li>Post-construction or move-out cleaning</li>
-              </ul>
+            <div class="addon-group" data-service-group="commercial,office">
+              <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
+              <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
+                <span class="addon-icon" data-icon="vacuum" aria-hidden="true"></span>
+                <span class="addon-name">Carpet Steam Cleaning Package</span>
+                <div class="addon-stepper" role="group" aria-label="Carpet Steam Cleaning Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Carpet Steam Cleaning quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Carpet Steam Cleaning quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
+                <span class="addon-icon" data-icon="tiles" aria-hidden="true"></span>
+                <span class="addon-name">Tile and Grout Cleaning Package</span>
+                <div class="addon-stepper" role="group" aria-label="Tile and Grout Cleaning Package quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Tile and Grout quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Tile and Grout quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-coral" data-addon="Window Detailing" data-price="120">
+                <span class="addon-icon" data-icon="squeegee" aria-hidden="true"></span>
+                <span class="addon-name">Window Detailing</span>
+                <div class="addon-stepper" role="group" aria-label="Window Detailing quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Window Detailing quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Window Detailing quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Window Detailing quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-lime" data-addon="Pressure Washing" data-price="165">
+                <span class="addon-icon" data-icon="pressure" aria-hidden="true"></span>
+                <span class="addon-name">Pressure Washing</span>
+                <div class="addon-stepper" role="group" aria-label="Pressure Washing quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Pressure Washing quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Pressure Washing quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Pressure Washing quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
+              <div class="addon-pill color-rose" data-addon="Floor Strip &amp; Wax" data-price="185">
+                <span class="addon-icon" data-icon="floor" aria-hidden="true"></span>
+                <span class="addon-name">Floor Strip &amp; Wax</span>
+                <div class="addon-stepper" role="group" aria-label="Floor Strip and Wax quantity">
+                  <button type="button" class="stepper-button" data-qty-step="-1" aria-label="Decrease Floor Strip and Wax quantity"><span aria-hidden="true">−</span></button>
+                  <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Floor Strip and Wax quantity">
+                  <button type="button" class="stepper-button" data-qty-step="1" aria-label="Increase Floor Strip and Wax quantity"><span aria-hidden="true">+</span></button>
+                </div>
+              </div>
             </div>
           </div>
+          <p id="addon-empty-message" class="addon-empty" hidden>No add-ons are available for the package you selected.</p>
           <div class="actions">
             <button type="button" class="btn back">Back</button>
             <button type="button" class="btn next">Next</button>
           </div>
         </fieldset>
 
-        <!-- STEP 4: Contact -->
-        <fieldset class="step" data-step="4" hidden>
+        <fieldset class="step" data-step="3" hidden>
           <legend>Your contact information</legend>
           <div class="grid-2">
             <label>
-              Full name
-              <input type="text" name="name" placeholder="Jane Smith" required />
+              First name
+              <input type="text" name="first_name" placeholder="Jane" autocomplete="given-name" required />
+            </label>
+            <label>
+              Last name (optional)
+              <input type="text" name="last_name" placeholder="Smith" autocomplete="family-name" />
             </label>
             <label>
               Email
-              <input type="email" name="email" placeholder="you@company.com" required />
+              <input type="email" name="email" placeholder="you@company.com" autocomplete="email" required />
             </label>
             <label>
               Phone
-              <input type="tel" name="phone" placeholder="(555) 555-5555" required />
+              <input type="tel" name="phone" placeholder="(555) 555-5555" autocomplete="tel" />
             </label>
             <label class="wide">
               Notes (optional)
@@ -437,18 +860,114 @@
           </div>
         </fieldset>
 
-        <!-- STEP 5: Review & Confirm -->
+        <fieldset class="step" data-step="4" hidden>
+          <legend>When &amp; where should we clean?</legend>
+          <div class="grid-2">
+            <label>
+              Business / Building Name
+              <input type="text" name="business" placeholder="Company or building" autocomplete="organization" />
+            </label>
+            <label>
+              Street Address
+              <input type="text" name="address" placeholder="123 Queen St" autocomplete="street-address" required />
+            </label>
+            <label>
+              City
+              <input type="text" name="city" placeholder="Toronto" autocomplete="address-level2" required />
+            </label>
+            <label>
+              Postal Code
+              <input type="text" name="postal" placeholder="M5H 2N2" autocomplete="postal-code" required />
+            </label>
+            <label>
+              Preferred Date
+              <input type="date" name="date" required />
+            </label>
+            <label>
+              Preferred Time Window
+              <select name="time" required>
+                <option value="">Select a time window</option>
+                <option value="morning">Morning (8am – 11am)</option>
+                <option value="midday">Midday (11am – 2pm)</option>
+                <option value="afternoon">Afternoon (2pm – 5pm)</option>
+              </select>
+            </label>
+            <label class="wide">
+              Square Footage (approx.)
+              <input type="number" name="sqft" min="100" step="50" placeholder="e.g., 5,000" />
+            </label>
+          </div>
+          <div class="actions">
+            <button type="button" class="btn back">Back</button>
+            <button type="button" class="btn next">Next</button>
+          </div>
+        </fieldset>
+
         <fieldset class="step" data-step="5" hidden>
-          <legend>Review &amp; Confirm</legend>
-          <dl class="review" id="reviewList">
-            <!-- Filled by JS -->
-          </dl>
+          <legend>Review &amp; confirm</legend>
+          <p class="muted">Double-check every detail below, then finalize your booking when you're ready. Your cart summary stays on the right for a quick final check.</p>
+          <dl class="review" id="reviewList"></dl>
           <div class="actions">
             <button type="button" class="btn back">Back</button>
             <button type="submit" class="btn submit">Submit</button>
           </div>
         </fieldset>
-      </form>
+
+            </div>
+
+            <aside class="cart-summary" id="cartSummary" aria-label="Cart summary">
+              <header>
+                <img id="cartSummaryImage" alt="Custom cleaning package" loading="lazy" />
+                <div>
+                  <h2 class="cart-summary-title">Custom Package</h2>
+                  <p class="cart-summary-subtitle" data-cart-service>Choose a service to view details.</p>
+                </div>
+              </header>
+              <div class="cart-details" data-cart-description hidden></div>
+              <div class="cart-pricing" id="pricingRecap">
+                <div class="cart-line">
+                  <span>Base package</span>
+                  <span data-recap-base>—</span>
+                </div>
+                <div class="cart-line" data-recap-detail-row hidden>
+                  <span>Service details</span>
+                  <span data-recap-detail>—</span>
+                </div>
+                <div class="cart-line" data-recap-extras-row hidden>
+                  <span>Add-ons</span>
+                  <span data-recap-extras>—</span>
+                </div>
+                <div class="cart-line" data-recap-discount-row hidden>
+                  <span>Frequency savings</span>
+                  <span data-recap-discount>—</span>
+                </div>
+                <div class="cart-divider"></div>
+                <div class="cart-line total">
+                  <span>Visit total</span>
+                  <span data-recap-total>—</span>
+                </div>
+                <div class="cart-line deposit">
+                  <span>Deposit (50%)</span>
+                  <span id="deposit-due-text">—</span>
+                </div>
+                <div class="cart-line balance">
+                  <span>Balance at service</span>
+                  <span id="balance-due-text">—</span>
+                </div>
+              </div>
+              <button type="button" class="btn cart-btn" id="addToCartBtn" disabled>Add package to cart</button>
+              <p class="cart-status" id="cartStatus" role="status" aria-live="polite"></p>
+              <div class="payment-policy">
+                <h3>Payment Policy</h3>
+                <p>A 50% deposit is required at the time of booking to secure your appointment. The remaining balance is due upon completion of the service. Deposits are non-refundable if cancellations occur within 48 hours of the scheduled cleaning.</p>
+              </div>
+            </aside>
+
+          </div>
+
+        </form>
+
+      </div>
 
       <div id="bookingSuccess" class="booking-success" hidden>
         <h2>Thanks! Your request has been received.</h2>
@@ -458,7 +977,6 @@
     </div>
   </section>
 
-  <!-- iOS detector -->
   <script>
     (function () {
       var iOS = /iP(hone|od|ad)/.test(navigator.platform) || (navigator.userAgent.includes('Mac') && navigator.maxTouchPoints > 1);
@@ -466,280 +984,1512 @@
     })();
   </script>
 
-  <!-- Booking wizard JS (unchanged, just scoped to this page) -->
+  <script>
+    (function(){
+      const quoteForms = Array.from(document.querySelectorAll('form.quote-form'));
+      if(!quoteForms.length) return;
+
+      const basePricing = {
+        home: {
+          '1000-1500': 165,
+          '1500-2000': 185,
+          '2000-2500': 215,
+          '2500-3000': 245,
+          '3000-3500': 285,
+          '3500-4000': 325
+        },
+        commercial: {
+          '1000-1500': 240,
+          '1500-2000': 285,
+          '2000-2500': 330,
+          '2500-3000': 380,
+          '3000-3500': 425,
+          '3500-4000': 470
+        },
+        office: {
+          '1000-1500': 210,
+          '1500-2000': 250,
+          '2000-2500': 295,
+          '2500-3000': 335,
+          '3000-3500': 375,
+          '3500-4000': 420
+        }
+      };
+
+      const detailPricing = {
+        home: {
+          rooms: { '1-2': 0, '3-4': 25, '5-6': 55, '7+': 85 },
+          bathrooms: { '1': 0, '2': 18, '3': 36, '4+': 54 },
+          pets: { no: 0, yes: 25 }
+        },
+        office: {
+          offices: { '1-5': 0, '6-10': 45, '11-20': 90, '21+': 135 },
+          bathrooms: { '1-2': 0, '3-4': 40, '5+': 70 }
+        }
+      };
+
+      quoteForms.forEach(setupQuoteForm);
+
+      function setupQuoteForm(form){
+        const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
+        const basePriceEl = form.querySelector('[data-quote-base]');
+        const detailRow = form.querySelector('[data-quote-detail-row]');
+        const detailPriceEl = form.querySelector('[data-quote-detail]');
+        const totalPriceEl = form.querySelector('[data-quote-total]');
+        const serviceInput = form.querySelector('input[name="service"]');
+        const sqftInput = form.querySelector('input[name="square-footage"]');
+        const serviceDetailsWrapper = form.querySelector('.service-details');
+        const detailGroups = serviceDetailsWrapper ? Array.from(serviceDetailsWrapper.querySelectorAll('[data-service-detail]')) : [];
+        const seePriceBtn = form.querySelector('.quote-see-price');
+        const pillControls = Array.from(form.querySelectorAll('[data-target-input]'));
+
+        function fieldIsRelevant(field){
+          const requirement = field.dataset.serviceRequired;
+          if(!requirement) return true;
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          if(!serviceKey) return false;
+          return requirement.split(',').includes(serviceKey);
+        }
+
+        function hasAllRequired(){
+          return requiredFields.every(field => {
+            if(!fieldIsRelevant(field)) return true;
+            const value = field.value ? field.value.trim() : '';
+            if(field.type === 'email'){
+              return value !== '' && value.includes('@');
+            }
+            return value !== '';
+          });
+        }
+
+        function resetServiceGroup(group){
+          const hiddenInputs = Array.from(group.querySelectorAll('input[type="hidden"]'));
+          hiddenInputs.forEach(input => {
+            input.value = '';
+            input.dataset.label = '';
+          });
+          const buttons = Array.from(group.querySelectorAll('[data-target-input]'));
+          buttons.forEach(btn => {
+            btn.classList.remove('active');
+            btn.setAttribute('aria-pressed', 'false');
+          });
+        }
+
+        function updateServiceDetails(serviceKey){
+          if(!serviceDetailsWrapper) return;
+          let activeCount = 0;
+          detailGroups.forEach(group => {
+            const services = (group.dataset.serviceDetail || '').split(',');
+            const match = serviceKey && services.includes(serviceKey);
+            group.classList.toggle('active', !!match);
+            group.setAttribute('aria-hidden', match ? 'false' : 'true');
+            if(match){
+              activeCount += 1;
+            } else {
+              resetServiceGroup(group);
+            }
+          });
+          serviceDetailsWrapper.classList.toggle('visible', activeCount > 0);
+          serviceDetailsWrapper.setAttribute('aria-hidden', activeCount > 0 ? 'false' : 'true');
+        }
+
+        function selectionInfo(input){
+          if(!input || !input.value) return null;
+          return {
+            value: input.value,
+            label: input.dataset.label || input.value
+          };
+        }
+
+        function calculateTotals(){
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          const sqftKey = sqftInput ? sqftInput.value : '';
+          if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
+            return { ready: false, base: 0, detail: 0, total: 0, selections: {}, serviceLabel: '', sqftLabel: '' };
+          }
+
+          const base = basePricing[serviceKey][sqftKey] || 0;
+          let detailAdjustment = 0;
+          const selections = {};
+
+          if(serviceKey === 'home'){
+            const roomsField = form.querySelector('input[name="home-rooms"]');
+            const bathsField = form.querySelector('input[name="home-bathrooms"]');
+            const petsField = form.querySelector('input[name="home-pets"]');
+
+            const roomsInfo = selectionInfo(roomsField);
+            const bathsInfo = selectionInfo(bathsField);
+            const petsInfo = selectionInfo(petsField);
+
+            if(roomsInfo){
+              detailAdjustment += detailPricing.home.rooms[roomsInfo.value] || 0;
+              selections.homeRooms = roomsInfo;
+            }
+            if(bathsInfo){
+              detailAdjustment += detailPricing.home.bathrooms[bathsInfo.value] || 0;
+              selections.homeBathrooms = bathsInfo;
+            }
+            if(petsInfo){
+              detailAdjustment += detailPricing.home.pets[petsInfo.value] || 0;
+              selections.homePets = petsInfo;
+            }
+          }
+
+          if(serviceKey === 'office'){
+            const officesField = form.querySelector('input[name="office-offices"]');
+            const officeBathsField = form.querySelector('input[name="office-bathrooms"]');
+
+            const officesInfo = selectionInfo(officesField);
+            const officeBathsInfo = selectionInfo(officeBathsField);
+
+            if(officesInfo){
+              detailAdjustment += detailPricing.office.offices[officesInfo.value] || 0;
+              selections.officeOffices = officesInfo;
+            }
+            if(officeBathsInfo){
+              detailAdjustment += detailPricing.office.bathrooms[officeBathsInfo.value] || 0;
+              selections.officeBathrooms = officeBathsInfo;
+            }
+          }
+
+          return {
+            ready: true,
+            base,
+            detail: detailAdjustment,
+            total: base + detailAdjustment,
+            selections,
+            serviceLabel: serviceInput?.dataset.label || serviceKey,
+            sqftLabel: sqftInput?.dataset.label || sqftKey
+          };
+        }
+
+        function formatCurrency(value){
+          if(!value) return '—';
+          return `$${Math.round(value)}`;
+        }
+
+        function updateTotals(){
+          const totals = calculateTotals();
+
+          if(basePriceEl){ basePriceEl.textContent = totals.ready ? formatCurrency(totals.base) : '—'; }
+          if(totalPriceEl){ totalPriceEl.textContent = totals.ready ? formatCurrency(totals.total) : '—'; }
+
+          if(detailRow && detailPriceEl){
+            if(totals.ready && totals.detail > 0){
+              detailRow.hidden = false;
+              detailPriceEl.textContent = `+$${Math.round(totals.detail)}`;
+            } else {
+              detailRow.hidden = true;
+              detailPriceEl.textContent = '—';
+            }
+          }
+
+          const ready = totals.ready && hasAllRequired();
+          form.classList.toggle('quote-ready', ready);
+          if(seePriceBtn){ seePriceBtn.disabled = !ready; }
+
+          return totals;
+        }
+
+        pillControls.forEach(control => {
+          const targetName = control.dataset.targetInput;
+          if(!targetName) return;
+          const hiddenInput = form.querySelector(`input[name="${targetName}"]`);
+          if(!hiddenInput) return;
+
+          control.setAttribute('aria-pressed', 'false');
+
+          control.addEventListener('click', () => {
+            const group = control.closest('[role="radiogroup"]') || control.parentElement;
+            if(group){
+              Array.from(group.querySelectorAll('[data-target-input="' + targetName + '"]')).forEach(btn => {
+                const active = btn === control;
+                btn.classList.toggle('active', active);
+                btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+              });
+            }
+
+            hiddenInput.value = control.dataset.value || '';
+            hiddenInput.dataset.label = control.dataset.label || hiddenInput.value;
+            hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
+            updateServiceDetails(serviceInput ? serviceInput.value : '');
+            updateTotals();
+          });
+        });
+
+        requiredFields.forEach(field => {
+          const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
+          field.addEventListener(eventName, updateTotals);
+        });
+
+        if(serviceInput){
+          serviceInput.addEventListener('change', () => {
+            updateServiceDetails(serviceInput.value);
+            updateTotals();
+          });
+        }
+
+        if(sqftInput){
+          sqftInput.addEventListener('change', updateTotals);
+        }
+
+        if(seePriceBtn){
+          seePriceBtn.addEventListener('click', () => {
+            if(seePriceBtn.disabled) return;
+            const totals = updateTotals();
+            if(!totals.ready) return;
+
+            const mode = form.dataset.quoteMode || 'redirect';
+            if(mode !== 'redirect') return;
+
+            const redirectTarget = form.dataset.redirect || 'book.html';
+            const url = new URL(redirectTarget, window.location.origin);
+            const params = url.searchParams;
+
+            const serviceValue = serviceInput ? serviceInput.value : '';
+            if(serviceValue){
+              params.set('service', serviceValue);
+              if(totals.serviceLabel){ params.set('serviceLabel', totals.serviceLabel); }
+            }
+
+            const sqftValue = sqftInput ? sqftInput.value : '';
+            if(sqftValue){
+              params.set('sqft', sqftValue);
+              if(totals.sqftLabel){ params.set('sqftLabel', totals.sqftLabel); }
+            }
+
+            params.set('basePrice', totals.base.toFixed(2));
+            params.set('detailPrice', totals.detail.toFixed(2));
+            params.set('total', totals.total.toFixed(2));
+
+            const firstName = form.querySelector('input[name="first-name"]');
+            if(firstName && firstName.value.trim()){
+              params.set('firstName', firstName.value.trim());
+            }
+
+            const email = form.querySelector('input[name="email"]');
+            if(email && email.value.trim()){
+              params.set('email', email.value.trim());
+            }
+
+            Object.entries(totals.selections || {}).forEach(([key, info]) => {
+              if(info.value){ params.set(key, info.value); }
+              if(info.label){ params.set(`${key}Label`, info.label); }
+            });
+
+            const anchor = form.dataset.redirectAnchor;
+            const finalUrl = anchor ? `${url.toString()}#${anchor}` : url.toString();
+            window.location.href = finalUrl;
+          });
+        }
+
+        updateServiceDetails(serviceInput ? serviceInput.value : '');
+        updateTotals();
+      }
+    })();
+  </script>
+
   <script>
     (function(){
       const form = document.getElementById('bookingForm');
-      const steps = Array.from(document.querySelectorAll('.step'));
-      const stepper = document.getElementById('stepper').children;
+      if(!form) return;
+
+      const steps = Array.from(form.querySelectorAll('.step'));
+      const stepper = Array.from(document.getElementById('stepper').children || []);
       const reviewList = document.getElementById('reviewList');
+      const successEl = document.getElementById('bookingSuccess');
+      const layoutEl = document.getElementById('bookingLayout');
+
+      const addonEmptyMessage = document.getElementById('addon-empty-message');
+
+      const hiddenServiceKey = document.getElementById('input-service-key');
+      const hiddenServiceLabel = document.getElementById('input-service-label');
+      const hiddenSqftLabel = document.getElementById('input-sqft-label');
+      const hiddenDetailSummary = document.getElementById('input-detail-summary');
+      const hiddenBasePrice = document.getElementById('input-base-price');
+      const hiddenDetailPrice = document.getElementById('input-detail-price');
+      const hiddenAddonsPrice = document.getElementById('input-addons-price');
+      const hiddenDiscountPrice = document.getElementById('input-discount-price');
+      const hiddenDepositPrice = document.getElementById('input-deposit-price');
+      const hiddenBalancePrice = document.getElementById('input-balance-price');
+      const hiddenTotalPrice = document.getElementById('input-total-price');
+      const hiddenSelectedAddons = document.getElementById('input-selected-addons');
+      const hiddenPackage = document.getElementById('input-package');
+      const hiddenPayPalOrder = document.getElementById('input-paypal-order-id');
+      const hiddenPayPalPayer = document.getElementById('input-paypal-payer-id');
+      const hiddenPayPalCapture = document.getElementById('input-paypal-capture-id');
+      const hiddenCartStatus = document.getElementById('input-cart-status');
+      const CART_IMAGE_DATA_URI = window.CART_IMAGE_DATA_URI || 'data:image/png;base64,' +
+        'iVBORw0KGgoAAAANSUhEUgAAAlgAAAGQCAIAAAD9V4nPAAAE0UlEQVR42u3VMQ0AAAgEsdeCXXyiAxNsNKmCWy7VAwBvRQIAjBAA' +
+        'jBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAA' +
+        'jBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAA' +
+        'I1QBACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACME' +
+        'ACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACME' +
+        'ACMEwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgB' +
+        'wAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgB' +
+        'wAgBwAgBwAgBMEIVADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBC' +
+        'ADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBC' +
+        'ADBCADBCADBCADBCADBCAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQ' +
+        'AIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQ' +
+        'AIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQACOUAAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAj' +
+        'BAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAj' +
+        'BAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBMAIVQDACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHA' +
+        'CAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHA' +
+        'CAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAEwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAw' +
+        'QgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgC4sEMVKv0E08xMAAAAAElFTkSuQmCC';
+      if(!window.CART_IMAGE_DATA_URI){
+        window.CART_IMAGE_DATA_URI = CART_IMAGE_DATA_URI;
+      }
+      const resolveCartImagePath = () => {
+        const candidates = [];
+        if(window.CART_IMAGE_PATH && typeof window.CART_IMAGE_PATH === 'string'){
+          candidates.push(window.CART_IMAGE_PATH);
+        }
+        if(document.body && document.body.dataset && typeof document.body.dataset.cartImage === 'string'){
+          candidates.push(document.body.dataset.cartImage);
+        }
+        for(const candidate of candidates){
+          if(candidate && typeof candidate === 'string' && candidate.trim()){
+            return candidate.trim();
+          }
+        }
+        return CART_IMAGE_DATA_URI;
+      };
+      const CART_IMAGE_PATH = resolveCartImagePath();
+      if(!window.CART_IMAGE_PATH){
+        window.CART_IMAGE_PATH = CART_IMAGE_PATH;
+      }
+      const cartImage = document.getElementById('cartSummaryImage');
+      if(cartImage && !cartImage.getAttribute('src')){
+        const fallback = CART_IMAGE_DATA_URI;
+        const targetSrc = CART_IMAGE_PATH || fallback;
+        const shouldListen = fallback && targetSrc !== fallback;
+        const handleImageError = () => {
+          cartImage.removeEventListener('error', handleImageError);
+          cartImage.src = fallback;
+        };
+        if(shouldListen){
+          cartImage.addEventListener('error', handleImageError);
+        }
+        cartImage.src = targetSrc;
+      }
+      const hiddenFullName = document.getElementById('input-full-name');
+      const originField = document.getElementById('input-origin');
+
+      const depositText = document.getElementById('deposit-due-text');
+      const balanceText = document.getElementById('balance-due-text');
+      const submitBtn = form.querySelector('.submit');
+
+      const recapBase = document.querySelector('[data-recap-base]');
+      const recapDetailRow = document.querySelector('[data-recap-detail-row]');
+      const recapDetail = document.querySelector('[data-recap-detail]');
+      const recapExtrasRow = document.querySelector('[data-recap-extras-row]');
+      const recapExtras = document.querySelector('[data-recap-extras]');
+      const recapDiscountRow = document.querySelector('[data-recap-discount-row]');
+      const recapDiscount = document.querySelector('[data-recap-discount]');
+      const recapTotal = document.querySelector('[data-recap-total]');
+      const recapDescription = document.querySelector('[data-cart-description]');
+      const cartService = document.querySelector('[data-cart-service]');
+      const addToCartBtn = document.getElementById('addToCartBtn');
+      const cartStatus = document.getElementById('cartStatus');
+      const cartSummaryEl = document.getElementById('cartSummary');
+      const navCartButton = document.querySelector('[data-cart-toggle]');
+      const navPayPalContainer = document.getElementById('nav-paypal-buttons');
+      const navPayPalStatus = document.getElementById('nav-paypal-status');
+
+      const frequencyInputs = Array.from(form.querySelectorAll('input[name="frequency"]'));
+      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
+      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+
+      const ADDON_ICON_SVGS = {
+        sparkle: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M16 5l2.2 5.8 6 .4-4.7 4 1.4 5.7-4.9-3.1-4.9 3.1 1.4-5.7-4.7-4 6-.4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M9.2 9.5l1.1 2.3 2.5.2-2 1.7.6 2.3-2.1-1.3-2.1 1.3.6-2.3-2-1.7 2.5-.2z" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" opacity=".6"/></svg>`,
+        truck: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M5 12h12v9H7a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M17 12h5l3 4v5h-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><circle cx="11.5" cy="23" r="2.4" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="23.5" cy="23" r="2.4" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M9 12V8.5A2.5 2.5 0 0 1 11.5 6H15" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        tool: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M19 6.5a4 4 0 0 0-5.4 5.4l-6.1 6.1 2.3 2.3 6.1-6.1a4 4 0 0 0 5.4-5.4l3.7-3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M13.8 14.2l7.5 7.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="23.5" cy="8.5" r="2.5" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>`,
+        cap: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M4 12l12-5 12 5-12 5-12-5z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M10 16v4.5c0 2.2 2.7 3.5 6 3.5s6-1.3 6-3.5V16" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M26 13.5v7" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        home: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M6 14l10-8 10 8v12H6V14z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M13 26v-7h6v7" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>`,
+        paw: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><circle cx="10" cy="12" r="2.2" fill="none" stroke="currentColor" stroke-width="1.4"/><circle cx="16" cy="10" r="2.4" fill="none" stroke="currentColor" stroke-width="1.4"/><circle cx="22" cy="12" r="2.2" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M11 19c0-3 2.7-5 5-5s5 2 5 5-2.2 6-5 6-5-3-5-6z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>`,
+        fridge: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><rect x="9" y="5" width="14" height="22" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.6"/><line x1="9" y1="15" x2="23" y2="15" stroke="currentColor" stroke-width="1.6"/><line x1="12.5" y1="11" x2="12.5" y2="13" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        oven: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><rect x="7" y="7" width="18" height="20" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="10" y="13" width="12" height="9" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="11" cy="10" r="1" fill="currentColor"/><circle cx="16" cy="10" r="1" fill="currentColor"/><circle cx="21" cy="10" r="1" fill="currentColor"/></svg>`,
+        cabinet: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><rect x="8" y="7" width="16" height="18" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.6"/><line x1="8" y1="15" x2="24" y2="15" stroke="currentColor" stroke-width="1.6"/><line x1="8" y1="21" x2="24" y2="21" stroke="currentColor" stroke-width="1.6"/><circle cx="16" cy="12" r="0.9" fill="currentColor"/><circle cx="16" cy="18" r="0.9" fill="currentColor"/><circle cx="16" cy="24" r="0.9" fill="currentColor"/></svg>`,
+        utensils: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M10 5v8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M8 5v4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M12 5v4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M21 13v14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M8 13v14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M12 13v14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M18 5a3 3 0 0 1 3 3v5.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        blinds: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><rect x="7" y="7" width="18" height="18" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.6"/><line x1="9" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><line x1="9" y1="16" x2="23" y2="16" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><line x1="9" y1="20" x2="23" y2="20" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M16 25v3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        window: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><rect x="7" y="7" width="18" height="18" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.6"/><line x1="16" y1="7" x2="16" y2="25" stroke="currentColor" stroke-width="1.6"/><line x1="7" y1="16" x2="25" y2="16" stroke="currentColor" stroke-width="1.6"/></svg>`,
+        bed: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M7 14h18a3 3 0 0 1 3 3v9H4v-9a3 3 0 0 1 3-3z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M10 14V9a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>`,
+        dish: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><circle cx="16" cy="16" r="9" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="16" cy="16" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M24 6v5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        spray: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M13 6h6l2 3h-6l-2-3z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M14 9h8l-2 4v11a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2V13l2-4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><circle cx="23" cy="7" r="1.2" fill="currentColor"/><circle cx="25.5" cy="7.5" r="0.9" fill="currentColor" opacity=".6"/></svg>`,
+        vacuum: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M18 10l4-4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M18 22V10a3 3 0 0 0-3-3h-3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M10 24a6 6 0 0 1 12 0" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M16 24v4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M12 24H8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M20 24h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        tiles: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><rect x="7" y="7" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6"/><line x1="13" y1="7" x2="13" y2="25" stroke="currentColor" stroke-width="1.6"/><line x1="19" y1="7" x2="19" y2="25" stroke="currentColor" stroke-width="1.6"/><line x1="7" y1="13" x2="25" y2="13" stroke="currentColor" stroke-width="1.6"/><line x1="7" y1="19" x2="25" y2="19" stroke="currentColor" stroke-width="1.6"/></svg>`,
+        squeegee: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M7 10h18l-2 6H9l-2-6z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M16 16v10" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M13 26h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`,
+        pressure: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><path d="M8 20h9a3 3 0 0 1 3 3v4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M14 20V10l4-2 2 3v4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/><path d="M22 9l4-2" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M22 11l4 1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M21 13l3.5 2" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" opacity=".7"/></svg>`,
+        floor: `<svg viewBox="0 0 32 32" aria-hidden="true" focusable="false"><circle cx="16" cy="22" r="6" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M16 22l6-14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M20 6h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M21 9h3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`
+      };
+
+      addonPills.forEach(pill => {
+        const iconSpan = pill.querySelector('.addon-icon[data-icon]');
+        if(iconSpan){
+          const key = iconSpan.dataset.icon || '';
+          if(ADDON_ICON_SVGS[key]){
+            iconSpan.innerHTML = ADDON_ICON_SVGS[key];
+          }
+        }
+      });
+      const paymentRadios = Array.from(form.querySelectorAll('input[name="payment_method"]'));
+      const paypalUi = document.querySelector('[data-payment-ui="paypal"]');
+      const paypalButtonsContainer = document.getElementById('paypal-buttons');
+      const paypalStatus = document.getElementById('paypal-status');
+      const PAYPAL_CONTEXTS = {};
+      if(paypalButtonsContainer){
+        PAYPAL_CONTEXTS.main = { container: paypalButtonsContainer, status: paypalStatus };
+      }
+      if(navPayPalContainer){
+        PAYPAL_CONTEXTS.nav = { container: navPayPalContainer, status: navPayPalStatus };
+      }
+
+      const DEPOSIT_RATE = 0.5;
+      const PAYPAL_CURRENCY = ((document.body && document.body.dataset && document.body.dataset.paypalCurrency) || 'CAD').toUpperCase();
+      const FREQUENCY_LABELS = {
+        weekly: 'Weekly (25% off)',
+        biweekly: 'Bi-Weekly (20% off)',
+        triweekly: 'Tri-Weekly (15% off)',
+        monthly: 'Monthly (10% off)',
+        biannual: 'Biannual (5% off)',
+        onetime: 'One-time'
+      };
+
+      const paypalButtonsInstances = {};
+      let paypalApproved = false;
+      let paypalApprovedAmount = 0;
+      let paypalScriptPromise = null;
       let current = 0;
+      let cartAdded = false;
+      let lastCartSignature = '';
+      let latestCartState = null;
+
+      const params = new URLSearchParams(window.location.search);
+      const SERVICE_LABELS = {
+        home: 'Home General Cleaning',
+        commercial: 'Factory / Commercial / Industrial Cleaning',
+        office: 'Office Workspace Cleaning'
+      };
+      const BASE_PRICE_TABLE = {
+        home: {
+          '1000-1500': 165,
+          '1500-2000': 185,
+          '2000-2500': 215,
+          '2500-3000': 245,
+          '3000-3500': 285,
+          '3500-4000': 325
+        },
+        commercial: {
+          '1000-1500': 240,
+          '1500-2000': 285,
+          '2000-2500': 330,
+          '2500-3000': 380,
+          '3000-3500': 425,
+          '3500-4000': 470
+        },
+        office: {
+          '1000-1500': 210,
+          '1500-2000': 250,
+          '2000-2500': 295,
+          '2500-3000': 335,
+          '3000-3500': 375,
+          '3500-4000': 420
+        }
+      };
+      const DETAIL_PRICE_TABLE = {
+        home: {
+          rooms: { '1-2': 0, '3-4': 25, '5-6': 55, '7+': 85 },
+          bathrooms: { '1': 0, '2': 18, '3': 36, '4+': 54 },
+          pets: { no: 0, yes: 25 },
+          basement: { no: 0, yes: 45 },
+          basementRooms: { '1-2': 25, '3-4': 45, '5+': 65 },
+          basementBathrooms: { '1': 18, '2': 32, '3+': 46 }
+        },
+        office: {
+          offices: { '1-5': 0, '6-10': 45, '11-20': 90, '21+': 135 },
+          bathrooms: { '1-2': 0, '3-4': 40, '5+': 70 }
+        }
+      };
+
+      const serviceKey = params.get('service') || '';
+      const rawServiceLabel = params.get('serviceLabel') || '';
+      const sqftKey = params.get('sqft') || '';
+      const rawSqftLabel = params.get('sqftLabel') || '';
+      let basePrice = Number(params.get('basePrice') || params.get('total') || 0);
+      let detailPrice = Number(params.get('detailPrice') || 0);
+      const totalParam = Number(params.get('total') || 0);
+      let totalBase = 0;
+
+      function formatSqftLabel(label, key){
+        if(label) return label;
+        if(!key) return '';
+        if(key.includes('-')){
+          const parts = key.split('-').map(part => parseInt(part, 10));
+          if(parts.length === 2 && parts.every(num => !Number.isNaN(num))){
+            return `${parts[0].toLocaleString()} – ${parts[1].toLocaleString()} sq ft`;
+          }
+        }
+        return key;
+      }
+
+      function deriveDetailPrice(service){
+        if(service === 'home'){
+          let total = 0;
+          const rooms = Number(params.get('homeRooms') || 0);
+          if(rooms){
+            if(rooms <= 2){ total += DETAIL_PRICE_TABLE.home.rooms['1-2'] || 0; }
+            else if(rooms <= 4){ total += DETAIL_PRICE_TABLE.home.rooms['3-4'] || 0; }
+            else if(rooms <= 6){ total += DETAIL_PRICE_TABLE.home.rooms['5-6'] || 0; }
+            else { total += DETAIL_PRICE_TABLE.home.rooms['7+'] || 0; }
+          }
+          const baths = Number(params.get('homeBathrooms') || 0);
+          if(baths){
+            if(baths <= 1){ total += DETAIL_PRICE_TABLE.home.bathrooms['1'] || 0; }
+            else if(baths <= 2){ total += DETAIL_PRICE_TABLE.home.bathrooms['2'] || 0; }
+            else if(baths <= 3){ total += DETAIL_PRICE_TABLE.home.bathrooms['3'] || 0; }
+            else { total += DETAIL_PRICE_TABLE.home.bathrooms['4+'] || 0; }
+          }
+          const pets = params.get('homePets');
+          if(pets && Object.prototype.hasOwnProperty.call(DETAIL_PRICE_TABLE.home.pets, pets)){
+            total += DETAIL_PRICE_TABLE.home.pets[pets] || 0;
+          }
+          const basement = params.get('homeBasement');
+          if(basement && Object.prototype.hasOwnProperty.call(DETAIL_PRICE_TABLE.home.basement, basement)){
+            total += DETAIL_PRICE_TABLE.home.basement[basement] || 0;
+            if(basement === 'yes'){
+              const basementRooms = Number(params.get('homeBasementRooms') || 0);
+              if(basementRooms){
+                if(basementRooms <= 2){ total += DETAIL_PRICE_TABLE.home.basementRooms['1-2'] || 0; }
+                else if(basementRooms <= 4){ total += DETAIL_PRICE_TABLE.home.basementRooms['3-4'] || 0; }
+                else { total += DETAIL_PRICE_TABLE.home.basementRooms['5+'] || 0; }
+              }
+              const basementBaths = Number(params.get('homeBasementBathrooms') || 0);
+              if(basementBaths){
+                if(basementBaths <= 1){ total += DETAIL_PRICE_TABLE.home.basementBathrooms['1'] || 0; }
+                else if(basementBaths <= 2){ total += DETAIL_PRICE_TABLE.home.basementBathrooms['2'] || 0; }
+                else { total += DETAIL_PRICE_TABLE.home.basementBathrooms['3+'] || 0; }
+              }
+            }
+          }
+          return total;
+        }
+        if(service === 'office'){
+          let total = 0;
+          const officesValue = params.get('officeOffices');
+          if(officesValue){
+            const officesKey = DETAIL_PRICE_TABLE.office.offices[officesValue] !== undefined
+              ? officesValue
+              : (() => {
+                  const count = Number(officesValue);
+                  if(!(count > 0)) return '';
+                  if(count <= 5) return '1-5';
+                  if(count <= 10) return '6-10';
+                  if(count <= 20) return '11-20';
+                  return '21+';
+                })();
+            if(officesKey && DETAIL_PRICE_TABLE.office.offices[officesKey] !== undefined){
+              total += DETAIL_PRICE_TABLE.office.offices[officesKey] || 0;
+            }
+          }
+          const officeBathsValue = params.get('officeBathrooms');
+          if(officeBathsValue){
+            const bathsKey = DETAIL_PRICE_TABLE.office.bathrooms[officeBathsValue] !== undefined
+              ? officeBathsValue
+              : (() => {
+                  const count = Number(officeBathsValue);
+                  if(!(count > 0)) return '';
+                  if(count <= 2) return '1-2';
+                  if(count <= 4) return '3-4';
+                  return '5+';
+                })();
+            if(bathsKey && DETAIL_PRICE_TABLE.office.bathrooms[bathsKey] !== undefined){
+              total += DETAIL_PRICE_TABLE.office.bathrooms[bathsKey] || 0;
+            }
+          }
+          return total;
+        }
+        return 0;
+      }
+
+      if(!(detailPrice > 0)){
+        const derivedDetail = deriveDetailPrice(serviceKey);
+        if(derivedDetail > 0){
+          detailPrice = derivedDetail;
+        }
+      }
+
+      if(!(basePrice > 0) && totalParam > 0){
+        const possibleBase = totalParam - detailPrice;
+        if(possibleBase > 0){
+          basePrice = possibleBase;
+        }
+      }
+
+      if(!(basePrice > 0) && serviceKey && sqftKey && BASE_PRICE_TABLE[serviceKey] && BASE_PRICE_TABLE[serviceKey][sqftKey]){
+        basePrice = BASE_PRICE_TABLE[serviceKey][sqftKey];
+      }
+
+      totalBase = basePrice + detailPrice;
+
+      const resolvedServiceLabel = rawServiceLabel || SERVICE_LABELS[serviceKey] || 'Custom Package';
+      const resolvedSqftLabel = formatSqftLabel(rawSqftLabel, sqftKey);
+
+      const detailSelections = [];
+      function pushDetail(label, value){
+        if(value){ detailSelections.push(label + ': ' + value); }
+      }
+      pushDetail('Service', resolvedServiceLabel || serviceKey);
+      pushDetail('Square Footage', resolvedSqftLabel || sqftKey);
+      pushDetail('Rooms', params.get('homeRoomsLabel'));
+      pushDetail('Bathrooms', params.get('homeBathroomsLabel'));
+      pushDetail('Pets', params.get('homePetsLabel'));
+      pushDetail('Basement', params.get('homeBasementLabel'));
+      pushDetail('Basement Rooms', params.get('homeBasementRoomsLabel'));
+      pushDetail('Basement Bathrooms', params.get('homeBasementBathroomsLabel'));
+      pushDetail('Offices', params.get('officeOfficesLabel'));
+      pushDetail('Office Bathrooms', params.get('officeBathroomsLabel'));
+
+      hiddenServiceKey.value = serviceKey;
+      hiddenServiceLabel.value = resolvedServiceLabel;
+      hiddenSqftLabel.value = resolvedSqftLabel;
+      const detailSummaryValue = detailSelections.join(' | ');
+      const detailSummaryDisplay = detailSelections.length
+        ? detailSelections.join(' • ')
+        : (totalBase > 0 ? 'Base package from instant quote.' : '');
+      hiddenDetailSummary.value = detailSummaryValue || (totalBase > 0 ? 'Base package from instant quote.' : '');
+      hiddenBasePrice.value = basePrice.toFixed(2);
+      hiddenDetailPrice.value = detailPrice.toFixed(2);
+      hiddenPackage.value = resolvedServiceLabel;
+
+      if(recapDescription){
+        if(detailSummaryDisplay){
+          recapDescription.hidden = false;
+          recapDescription.textContent = detailSummaryDisplay;
+        } else {
+          recapDescription.hidden = true;
+          recapDescription.textContent = '';
+        }
+      }
+
+      if(cartService){
+        cartService.textContent = (resolvedServiceLabel || 'Custom Package');
+      }
+
+      if(originField){
+        originField.value = serviceKey ? 'instant-quote' : 'book-page';
+      }
+
+      const sqftInput = form.querySelector('input[name="sqft"]');
+      if(sqftInput && sqftKey){
+        const avg = (() => {
+          if(sqftKey.includes('-')){
+            const parts = sqftKey.split('-').map(p => parseInt(p, 10));
+            if(parts.length === 2 && parts.every(n => !Number.isNaN(n))){
+              return Math.round((parts[0] + parts[1]) / 2);
+            }
+          }
+          return '';
+        })();
+        if(avg) sqftInput.value = avg;
+      }
+
+      const firstNameField = form.querySelector('input[name="first_name"]');
+      const lastNameField = form.querySelector('input[name="last_name"]');
+      const emailField = form.querySelector('input[name="email"]');
+      const quoteFirst = params.get('firstName') || '';
+      const quoteLast = params.get('lastName') || '';
+      const quoteFull = params.get('fullName') || '';
+      const quoteEmail = params.get('email');
+      if(firstNameField){
+        if(quoteFirst){
+          firstNameField.value = quoteFirst.trim();
+        } else if(quoteFull){
+          firstNameField.value = quoteFull.trim().split(/\s+/)[0] || '';
+        }
+      }
+      if(lastNameField){
+        if(quoteLast){
+          lastNameField.value = quoteLast.trim();
+        } else if(quoteFull){
+          const parts = quoteFull.trim().split(/\s+/);
+          if(parts.length > 1){ lastNameField.value = parts.slice(1).join(' '); }
+        }
+      }
+      if(emailField && quoteEmail) emailField.value = quoteEmail.trim();
+
+      function syncFullName(){
+        if(!hiddenFullName) return;
+        const first = firstNameField ? firstNameField.value.trim() : '';
+        const last = lastNameField ? lastNameField.value.trim() : '';
+        hiddenFullName.value = [first, last].filter(Boolean).join(' ');
+      }
+      syncFullName();
+      if(firstNameField) firstNameField.addEventListener('input', syncFullName);
+      if(lastNameField) lastNameField.addEventListener('input', syncFullName);
+
+      function formatCurrency(value){
+        if(!value) return '—';
+        return `$${Math.round(value).toString()}`;
+      }
+
+      function updateAddonVisibility(){
+        let visibleGroups = 0;
+        addonGroups.forEach(group => {
+          const services = (group.dataset.serviceGroup || '').split(',');
+          const active = serviceKey && services.includes(serviceKey);
+          group.classList.toggle('active', active);
+          if(active) visibleGroups += 1;
+        });
+        if(addonEmptyMessage){ addonEmptyMessage.hidden = visibleGroups !== 0; }
+      }
+      updateAddonVisibility();
+
+      function dispatchNavCartUpdate(justAdded){
+        if(typeof window.updateNavCartPopover !== 'function') return;
+        if(!latestCartState){
+          window.updateNavCartPopover(null);
+          return;
+        }
+        const snapshot = Object.assign({}, latestCartState);
+        if(justAdded){ snapshot.justAdded = true; }
+        window.updateNavCartPopover(snapshot);
+      }
+
+      function triggerCartFlight(){
+        if(!cartSummaryEl || !navCartButton) return;
+        const start = cartSummaryEl.getBoundingClientRect();
+        const end = navCartButton.getBoundingClientRect();
+        if(!start.width || !end.width) return;
+
+        const flight = document.createElement('div');
+        flight.className = 'cart-flight';
+        const img = document.createElement('img');
+        const preview = cartSummaryEl.querySelector('img');
+        img.src = (preview && preview.src) ? preview.src : CART_IMAGE_DATA_URI;
+        img.alt = '';
+        img.setAttribute('aria-hidden', 'true');
+        flight.appendChild(img);
+
+        const size = Math.max(Math.min(start.width, 140), 76);
+        flight.style.width = `${size}px`;
+        flight.style.height = `${size}px`;
+        flight.style.left = `${start.left + (start.width / 2) - (size / 2)}px`;
+        flight.style.top = `${start.top + (start.height / 2) - (size / 2)}px`;
+
+        document.body.appendChild(flight);
+
+        const deltaX = end.left + end.width / 2 - (start.left + start.width / 2);
+        const deltaY = end.top + end.height / 2 - (start.top + start.height / 2);
+
+        flight.style.opacity = '1';
+        const animation = flight.animate([
+          { transform: 'translate3d(0,0,0) scale(1)', opacity: 1 },
+          { transform: `translate3d(${deltaX}px, ${deltaY}px, 0) scale(0.35)`, opacity: 0 }
+        ], {
+          duration: 720,
+          easing: 'cubic-bezier(0.2, 0.75, 0.12, 1)'
+        });
+
+        animation.onfinish = () => flight.remove();
+        animation.oncancel = () => flight.remove();
+
+        cartSummaryEl.classList.add('cart-summary-flight');
+        window.setTimeout(() => {
+          cartSummaryEl.classList.remove('cart-summary-flight');
+        }, 640);
+      }
+
+      function ensureCartAdded(options){
+        if(cartAdded) return;
+        const freqInput = selectedFrequency();
+        if(!freqInput) return;
+        cartAdded = true;
+        refreshCartButton();
+        if(cartStatus){
+          cartStatus.classList.remove('error');
+          cartStatus.textContent = 'Package added to your cart. Continue through the steps to finalize.';
+        }
+        if(options && options.animate){
+          triggerCartFlight();
+        }
+        updateSummary();
+        dispatchNavCartUpdate(true);
+      }
+
+      const extrasState = [];
+      function computeExtras(){
+        extrasState.length = 0;
+        addonPills.forEach(pill => {
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+          if(!pill.classList.contains('active')) return;
+          const qtyInput = pill.querySelector('.addon-qty');
+          const qty = qtyInput ? Math.max(Number(qtyInput.value) || 1, Number(qtyInput.min) || 1) : 1;
+          const price = Number(pill.dataset.price || 0);
+          const name = pill.querySelector('.addon-name')?.textContent.trim() || pill.dataset.addon || 'Addon';
+          extrasState.push({ name, qty, price });
+        });
+        return extrasState;
+      }
+
+      function buildExtrasLabel(){
+        if(!extrasState.length) return '';
+        return extrasState.map(item => `${item.name} ×${item.qty}`).join(', ');
+      }
+
+      function getSelectedPayment(){
+        const selected = paymentRadios.find(radio => radio.checked);
+        return selected ? selected.value : null;
+      }
+
+      function clearPayPalHidden(){
+        if(hiddenPayPalOrder) hiddenPayPalOrder.value = '';
+        if(hiddenPayPalPayer) hiddenPayPalPayer.value = '';
+        if(hiddenPayPalCapture) hiddenPayPalCapture.value = '';
+      }
+
+      function setPayPalStatus(message, tone, context){
+        const keys = context ? [context] : Object.keys(PAYPAL_CONTEXTS);
+        keys.forEach(key => {
+          const entry = PAYPAL_CONTEXTS[key];
+          if(!entry || !entry.status) return;
+          entry.status.textContent = message || '';
+          entry.status.classList.toggle('error', tone === 'error');
+          entry.status.hidden = !message;
+        });
+      }
+
+      function syncSubmitDisabled(){
+        if(!submitBtn) return;
+        const method = getSelectedPayment();
+        submitBtn.disabled = method === 'paypal' && !paypalApproved;
+      }
+
+      function togglePayPalUi(show){
+        if(paypalUi){
+          paypalUi.hidden = !show;
+        }
+        if(!show){
+          setPayPalStatus('', 'info');
+        }
+      }
+
+      function resetPayPalApproval(message, tone){
+        paypalApproved = false;
+        paypalApprovedAmount = 0;
+        clearPayPalHidden();
+        if(message && getSelectedPayment() === 'paypal'){
+          setPayPalStatus(message, tone || 'info');
+        } else if(!message){
+          setPayPalStatus('', 'info');
+        }
+        syncSubmitDisabled();
+      }
+
+      function resolvePayPalClientId(){
+        if(document.body && document.body.dataset && document.body.dataset.paypalClientId){
+          return document.body.dataset.paypalClientId.trim();
+        }
+        if(typeof window !== 'undefined' && window.PAYPAL_CLIENT_ID){
+          return String(window.PAYPAL_CLIENT_ID).trim();
+        }
+        return '';
+      }
+
+      function loadPayPalSdk(){
+        if(window.paypal && typeof window.paypal.Buttons === 'function'){
+          return Promise.resolve(window.paypal);
+        }
+        if(paypalScriptPromise){
+          return paypalScriptPromise;
+        }
+
+        const clientId = resolvePayPalClientId();
+        if(!clientId){
+          const err = new Error('PayPal client ID is not configured.');
+          paypalScriptPromise = Promise.reject(err);
+          paypalScriptPromise.catch(() => { paypalScriptPromise = null; });
+          return paypalScriptPromise;
+        }
+
+        paypalScriptPromise = new Promise((resolve, reject) => {
+          const script = document.createElement('script');
+          const params = new URLSearchParams({
+            'client-id': clientId,
+            currency: PAYPAL_CURRENCY,
+            intent: 'capture'
+          });
+          script.src = `https://www.paypal.com/sdk/js?${params.toString()}`;
+          script.async = true;
+          script.onload = () => {
+            if(window.paypal && typeof window.paypal.Buttons === 'function'){
+              resolve(window.paypal);
+            } else {
+              reject(new Error('PayPal SDK loaded but Buttons API is unavailable.'));
+            }
+          };
+          script.onerror = () => {
+            reject(new Error('PayPal SDK failed to load.'));
+          };
+          document.head.appendChild(script);
+        }).catch(err => {
+          paypalScriptPromise = null;
+          throw err;
+        });
+
+        return paypalScriptPromise;
+      }
+
+      function destroyPayPalButtons(context){
+        const entry = PAYPAL_CONTEXTS[context];
+        if(!entry || !entry.container) return;
+        if(paypalButtonsInstances[context] && typeof paypalButtonsInstances[context].close === 'function'){
+          try { paypalButtonsInstances[context].close(); } catch(_) {}
+        }
+        delete paypalButtonsInstances[context];
+        entry.container.innerHTML = '';
+      }
+
+      function ensurePayPalButtons(context = 'main'){
+        const entry = PAYPAL_CONTEXTS[context];
+        if(!entry || !entry.container) return;
+        if(paypalButtonsInstances[context]) return;
+
+        setPayPalStatus('Loading PayPal…', 'info', context);
+        loadPayPalSdk().then(paypal => {
+          if(paypalButtonsInstances[context]){
+            return paypalButtonsInstances[context];
+          }
+
+          entry.container.innerHTML = '';
+          const buttons = paypal.Buttons({
+            style: {
+              layout: 'vertical',
+              color: 'gold',
+              label: 'pay',
+              shape: 'rect'
+            },
+            onClick(data, actions){
+              const deposit = Number(hiddenDepositPrice.value || 0);
+              if(!(deposit > 0)){
+                setPayPalStatus('Finish selecting your services so we can calculate the deposit before paying with PayPal.', 'error');
+                return actions.reject();
+              }
+              paypalApproved = false;
+              paypalApprovedAmount = 0;
+              clearPayPalHidden();
+              syncSubmitDisabled();
+              setPayPalStatus('Redirecting to PayPal…');
+              return actions.resolve();
+            },
+            createOrder(data, actions){
+              const deposit = Number(hiddenDepositPrice.value || 0);
+              if(!(deposit > 0)){
+                setPayPalStatus('Your deposit total is missing. Adjust your booking details before checking out with PayPal.', 'error');
+                return actions.reject();
+              }
+              const amount = (Math.round(deposit * 100) / 100).toFixed(2);
+              return actions.order.create({
+                purchase_units: [{
+                  amount: {
+                    currency_code: PAYPAL_CURRENCY,
+                    value: amount
+                  },
+                  description: 'Dufferin Deep Clean 50% deposit'
+                }],
+                application_context: {
+                  shipping_preference: 'NO_SHIPPING'
+                }
+              });
+            },
+            onApprove(data, actions){
+              setPayPalStatus('Processing your PayPal payment…');
+              return actions.order.capture().then(details => {
+                paypalApproved = true;
+                paypalApprovedAmount = Math.round(Number(hiddenDepositPrice.value || 0) * 100) / 100;
+                if(hiddenPayPalOrder) hiddenPayPalOrder.value = data.orderID || details.id || '';
+                if(hiddenPayPalPayer) hiddenPayPalPayer.value = details?.payer?.payer_id || '';
+                const capture = details?.purchase_units?.[0]?.payments?.captures?.[0];
+                if(hiddenPayPalCapture) hiddenPayPalCapture.value = capture?.id || '';
+                const payerName = details?.payer?.name?.given_name || 'PayPal customer';
+                setPayPalStatus(`Deposit received from ${payerName}. You can now submit your booking.`);
+                syncSubmitDisabled();
+                buildReview();
+                dispatchNavCartUpdate(false);
+              }).catch(err => {
+                console.error('PayPal capture error', err);
+                resetPayPalApproval();
+                setPayPalStatus('PayPal could not capture the payment. Please try again.', 'error');
+                throw err;
+              });
+            },
+            onCancel(){
+              resetPayPalApproval('PayPal checkout was cancelled. You can try again or contact us for assistance.', 'error');
+            },
+            onError(err){
+              console.error('PayPal error', err);
+              resetPayPalApproval('PayPal reported an error. Please try again or contact us for assistance.', 'error');
+            }
+          });
+
+          paypalButtonsInstances[context] = buttons;
+          return buttons.render(entry.container).catch(err => {
+            console.error('PayPal render error', err);
+            destroyPayPalButtons(context);
+            resetPayPalApproval('PayPal could not initialize. Refresh the page or contact us for assistance.', 'error');
+            throw err;
+          });
+        }).catch(err => {
+          console.error('PayPal load error', err);
+          destroyPayPalButtons(context);
+          const message = 'PayPal checkout is currently unavailable. Please contact us to complete your deposit.';
+          setPayPalStatus(message, 'error', context);
+        });
+      }
+
+      document.addEventListener('nav-cart:opened', () => {
+        ensurePayPalButtons('nav');
+      });
+
+      function applyPaymentSelection(){
+        const method = getSelectedPayment();
+        if(method === 'paypal'){
+          togglePayPalUi(true);
+          ensurePayPalButtons('main');
+          ensurePayPalButtons('nav');
+          if(paypalApproved){
+            setPayPalStatus('PayPal deposit approved. You can submit your booking.');
+          } else {
+            setPayPalStatus('Complete your PayPal deposit to enable submission.');
+          }
+        } else {
+          togglePayPalUi(false);
+          resetPayPalApproval('');
+          setPayPalStatus('', 'info');
+        }
+        syncSubmitDisabled();
+      }
+
+      function selectedFrequency(){
+        return frequencyInputs.find(input => input.checked) || null;
+      }
+
+      function refreshCartButton(){
+        if(addToCartBtn){
+          addToCartBtn.textContent = cartAdded ? 'Added to cart' : 'Add package to cart';
+          addToCartBtn.classList.toggle('is-added', cartAdded);
+        }
+        if(hiddenCartStatus){
+          hiddenCartStatus.value = cartAdded ? 'added' : 'pending';
+        }
+        if(cartSummaryEl){
+          cartSummaryEl.classList.toggle('is-added', cartAdded);
+        }
+      }
+
+      function updateSummary(){
+        const extras = computeExtras();
+        const extrasTotal = extras.reduce((sum, item) => sum + item.price * item.qty, 0);
+        const freqInput = selectedFrequency();
+        const discountRate = freqInput ? Number(freqInput.dataset.discount || 0) : 0;
+        const subtotal = totalBase + extrasTotal;
+        const discount = subtotal * discountRate;
+        const finalTotal = subtotal - discount;
+        const depositDue = finalTotal > 0 ? finalTotal * DEPOSIT_RATE : 0;
+        const balanceDue = finalTotal > 0 ? Math.max(finalTotal - depositDue, 0) : 0;
+
+        const baseLabel = hiddenServiceLabel.value || resolvedServiceLabel || serviceKey || 'Custom Package';
+        const freqLabel = freqInput ? (FREQUENCY_LABELS[freqInput.value] || freqInput.value) : '';
+
+        if(cartService){
+          cartService.textContent = freqLabel ? `${baseLabel} • ${freqLabel}` : baseLabel;
+        }
+
+        if(depositText){ depositText.textContent = depositDue > 0 ? `$${Math.round(depositDue)}` : '—'; }
+        if(balanceText){ balanceText.textContent = balanceDue > 0 ? `$${Math.round(balanceDue)}` : '—'; }
+
+        if(recapBase){ recapBase.textContent = basePrice > 0 ? `$${Math.round(basePrice)}` : '—'; }
+        if(recapDetailRow && recapDetail){
+          if(detailPrice > 0){
+            recapDetailRow.hidden = false;
+            recapDetail.textContent = `+$${Math.round(detailPrice)}`;
+          } else {
+            recapDetailRow.hidden = true;
+            recapDetail.textContent = '—';
+          }
+        }
+        if(recapExtrasRow && recapExtras){
+          if(extrasTotal > 0){
+            recapExtrasRow.hidden = false;
+            recapExtras.textContent = `+$${Math.round(extrasTotal)}`;
+          } else {
+            recapExtrasRow.hidden = true;
+            recapExtras.textContent = '—';
+          }
+        }
+        if(recapDiscountRow && recapDiscount){
+          if(discount > 0){
+            recapDiscountRow.hidden = false;
+            recapDiscount.textContent = `-$${Math.round(discount)}`;
+          } else {
+            recapDiscountRow.hidden = true;
+            recapDiscount.textContent = '—';
+          }
+        }
+        if(recapTotal){
+          recapTotal.textContent = finalTotal > 0 ? `$${Math.round(finalTotal)}` : '—';
+        }
+
+        if(hiddenAddonsPrice) hiddenAddonsPrice.value = extrasTotal.toFixed(2);
+        if(hiddenDiscountPrice) hiddenDiscountPrice.value = discount.toFixed(2);
+        if(hiddenDepositPrice) hiddenDepositPrice.value = depositDue.toFixed(2);
+        if(hiddenBalancePrice) hiddenBalancePrice.value = balanceDue.toFixed(2);
+        if(hiddenTotalPrice) hiddenTotalPrice.value = finalTotal.toFixed(2);
+        const extrasLabel = buildExtrasLabel();
+        if(hiddenSelectedAddons) hiddenSelectedAddons.value = extrasLabel;
+
+        const signature = [basePrice, detailPrice, extrasTotal, discount, finalTotal].map(value => Math.round(value * 100) / 100).join('|');
+        if(signature !== lastCartSignature){
+          const wasAdded = cartAdded;
+          lastCartSignature = signature;
+          if(wasAdded){
+            cartAdded = false;
+            refreshCartButton();
+            if(cartStatus){
+              cartStatus.classList.remove('error');
+              cartStatus.textContent = 'Totals updated. Add the package to your cart again when ready.';
+            }
+          } else if(cartStatus && cartStatus.textContent && cartStatus.textContent.includes('Totals updated')){
+            cartStatus.textContent = '';
+          }
+        }
+
+        const normalizedDeposit = Math.round(depositDue * 100) / 100;
+        if(paypalApproved && Math.abs(normalizedDeposit - paypalApprovedAmount) > 0.01){
+          paypalApproved = false;
+          paypalApprovedAmount = 0;
+          clearPayPalHidden();
+          if(getSelectedPayment() === 'paypal'){
+            setPayPalStatus('Your deposit total changed. Please approve the PayPal payment again.');
+          }
+        }
+
+        if(addToCartBtn){
+          const canAdd = current >= 1 && !!freqInput;
+          addToCartBtn.disabled = cartAdded ? true : !canAdd;
+          if(!canAdd){
+            if(!cartAdded && cartStatus){
+              cartStatus.classList.remove('error');
+              cartStatus.textContent = 'Finish steps 1–2 to add this package to your cart.';
+            }
+          } else if(!cartAdded && cartStatus && cartStatus.textContent === 'Finish steps 1–2 to add this package to your cart.'){
+            cartStatus.textContent = '';
+          }
+        }
+
+        refreshCartButton();
+        syncSubmitDisabled();
+
+        latestCartState = {
+          cartAdded,
+          quantity: 1,
+          serviceLabel: baseLabel,
+          frequencyLabel: freqLabel,
+          basePrice,
+          detailPrice,
+          extrasTotal,
+          extrasLabel,
+          discount,
+          total: finalTotal,
+          deposit: depositDue,
+          balance: balanceDue,
+          checkoutUrl: 'book.html#cartSummary',
+          status: cartStatus && cartStatus.textContent ? cartStatus.textContent : ''
+        };
+        dispatchNavCartUpdate(false);
+      }
+
+      function adjustAddonQuantity(input, delta){
+        if(!input || !Number.isFinite(delta)) return;
+        const step = Number(input.step || 1) || 1;
+        const min = input.min !== '' ? Number(input.min) : 1;
+        const max = input.max !== '' ? Number(input.max) : null;
+        const current = input.value === '' ? min : Number(input.value);
+        let next = Number.isFinite(current) ? current + delta * step : min;
+        if(next < min) next = min;
+        if(max !== null && Number.isFinite(max)) next = Math.min(next, max);
+        input.value = String(next);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+
+      addonPills.forEach(pill => {
+        const qtyInput = pill.querySelector('.addon-qty');
+        if(qtyInput){
+          qtyInput.disabled = true;
+        }
+
+        pill.addEventListener('click', (event) => {
+          if(event.target === qtyInput || event.target.closest('.addon-stepper')) return;
+          const parent = pill.closest('.addon-group');
+          if(!parent || !parent.classList.contains('active')) return;
+
+          pill.classList.toggle('active');
+          const active = pill.classList.contains('active');
+          pill.setAttribute('aria-pressed', active ? 'true' : 'false');
+          if(qtyInput){
+            qtyInput.disabled = !active;
+            if(active && (!qtyInput.value || Number(qtyInput.value) < Number(qtyInput.min || 1))){
+              qtyInput.value = qtyInput.min || 1;
+            }
+          }
+          updateSummary();
+        });
+
+        pill.addEventListener('keydown', evt => {
+          if(evt.key === 'Enter' || evt.key === ' '){
+            evt.preventDefault();
+            pill.click();
+          }
+        });
+
+        pill.setAttribute('tabindex', '0');
+        pill.setAttribute('role', 'button');
+        pill.setAttribute('aria-pressed', 'false');
+
+        if(qtyInput){
+          qtyInput.addEventListener('input', () => {
+            if(!pill.classList.contains('active')) return;
+            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min || 1)){
+              qtyInput.value = qtyInput.min || 1;
+            }
+            updateSummary();
+          });
+
+          const stepperButtons = pill.querySelectorAll('.stepper-button');
+          stepperButtons.forEach(button => {
+            button.addEventListener('click', (event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              const delta = Number(button.dataset.qtyStep || button.dataset.step || 0);
+              if(!delta) return;
+              const parent = pill.closest('.addon-group');
+              if(parent && !parent.classList.contains('active')) return;
+              if(!pill.classList.contains('active')){
+                pill.classList.add('active');
+                pill.setAttribute('aria-pressed', 'true');
+                qtyInput.disabled = false;
+                if(!qtyInput.value || Number(qtyInput.value) < Number(qtyInput.min || 1)){
+                  qtyInput.value = qtyInput.min || 1;
+                }
+              }
+              adjustAddonQuantity(qtyInput, delta);
+            });
+          });
+        }
+      });
+
+      frequencyInputs.forEach(input => {
+        input.addEventListener('change', updateSummary);
+      });
+
+      paymentRadios.forEach(radio => {
+        radio.addEventListener('change', applyPaymentSelection);
+      });
+
+      if(addToCartBtn){
+        addToCartBtn.addEventListener('click', () => {
+          if(addToCartBtn.disabled) return;
+          cartAdded = true;
+          refreshCartButton();
+          if(cartStatus){
+            cartStatus.classList.remove('error');
+            cartStatus.textContent = 'Package added to your cart. Continue through the steps to finalize.';
+          }
+          triggerCartFlight();
+          updateSummary();
+          dispatchNavCartUpdate(true);
+        });
+      }
 
       function showStep(i){
-        steps.forEach((s, idx)=>{ s.hidden = idx !== i; });
-        Array.from(stepper).forEach((li, idx)=>{
-          li.classList.toggle('active', idx === i);
-          li.classList.toggle('done', idx < i);
+        steps.forEach((step, idx) => { step.hidden = idx !== i; });
+        stepper.forEach((item, idx) => {
+          item.classList.toggle('active', idx === i);
+          item.classList.toggle('done', idx < i);
         });
         current = i;
-        if (i === 4) buildReview(); // step index 4 = "Step 5"
+        updateSummary();
         window.scrollTo({ top: 0, behavior: 'smooth' });
+        if(i === steps.length - 1){
+          buildReview();
+          applyPaymentSelection();
+        }
       }
 
-      document.addEventListener('click', (e)=>{
-        if(e.target.matches('.next')){
-          const vis = steps[current];
-          const req = vis.querySelectorAll('[required]');
-          for (const el of req){ if(!el.value){ el.focus(); return; } }
-          showStep(Math.min(current+1, steps.length-1));
+      document.addEventListener('click', (event) => {
+        if(event.target.matches('.next')){
+          const visible = steps[current];
+          const required = Array.from(visible.querySelectorAll('[required]'));
+          for(const field of required){
+            if(!field.value){
+              field.focus();
+              if(field.reportValidity){ field.reportValidity(); }
+              return;
+            }
+          }
+          const prevIndex = current;
+          const nextIndex = Math.min(current + 1, steps.length - 1);
+          showStep(nextIndex);
+          if(prevIndex === 1 && nextIndex >= 2){
+            ensureCartAdded({ animate: true });
+          }
         }
-        if(e.target.matches('.back')){
-          showStep(Math.max(current-1, 0));
+        if(event.target.matches('.back')){
+          showStep(Math.max(current - 1, 0));
         }
       });
 
-      form.addEventListener('submit', (e)=>{
-        e.preventDefault();
-        // Let Formspree submit normally:
-        form.submit();
-        // If you prefer the inline success card instead, uncomment below:
-        // form.hidden = true;
-        // document.getElementById('bookingSuccess').hidden = false;
-      });
-
-      // package descriptions toggle
-      const pkg = document.getElementById('package');
-      function updatePkg(){
-        const blocks = {
-          industrial: document.getElementById('pkg-industrial'),
-          office: document.getElementById('pkg-office'),
-          specialty: document.getElementById('pkg-specialty')
-        };
-        Object.values(blocks).forEach(b=> b.hidden = true);
-        if (blocks[pkg.value]) blocks[pkg.value].hidden = false;
-      }
-      if(pkg){ pkg.addEventListener('change', updatePkg); }
-
-      // Build the review summary
       function buildReview(){
+        if(!reviewList) return;
+        syncFullName();
         const fd = new FormData(form);
-        const freqMap = {
-          weekly: 'Weekly (25% off)',
-          biweekly: 'Bi-Weekly (20% off)',
-          triweekly: 'Tri-Weekly (15% off)',
-          monthly: 'Monthly (10% off)',
-          biannual: 'Biannual (5% off)',
-          onetime: 'One-time'
-        };
-        const pkgMap = {
-          industrial: '🏭 Industrial & Warehouse Care',
-          office: '🖥️ Office & Corporate Cleaning',
-          specialty: '🪟 Specialty Facility Services'
-        };
+        const fullName = (() => {
+          const fields = [fd.get('first_name'), fd.get('last_name')].filter(Boolean).map(v => v.trim());
+          if(hiddenFullName && hiddenFullName.value) return hiddenFullName.value;
+          if(fields.length) return fields.join(' ');
+          return '';
+        })();
+        if(hiddenFullName && !hiddenFullName.value){
+          hiddenFullName.value = fullName;
+        }
 
         const rows = [
+          ['Service', hiddenServiceLabel.value || '—'],
+          ['Square Footage', hiddenSqftLabel.value || fd.get('sqft') || '—'],
+          ['Details', hiddenDetailSummary.value || '—'],
+          ['Frequency', FREQUENCY_LABELS[fd.get('frequency')] || '—'],
+          ['Add-ons', hiddenSelectedAddons.value || 'None'],
+          ['Base Package', hiddenBasePrice.value ? `$${Math.round(Number(hiddenBasePrice.value))}` : '—'],
+          ['Service Details', hiddenDetailPrice.value ? `$${Math.round(Number(hiddenDetailPrice.value))}` : '—'],
+          ['Add-on Total', hiddenAddonsPrice.value ? `$${Math.round(Number(hiddenAddonsPrice.value))}` : '—'],
+          ['Frequency Savings', hiddenDiscountPrice.value && Number(hiddenDiscountPrice.value) ? `-$${Math.round(Number(hiddenDiscountPrice.value))}` : '—'],
+          ['Deposit Due Today', hiddenDepositPrice.value && Number(hiddenDepositPrice.value) ? `$${Math.round(Number(hiddenDepositPrice.value))}` : '—'],
+          ['Balance at Service', hiddenBalancePrice.value && Number(hiddenBalancePrice.value) ? `$${Math.round(Number(hiddenBalancePrice.value))}` : '—'],
+          ['Estimated Visit Total', hiddenTotalPrice.value && Number(hiddenTotalPrice.value) ? `$${Math.round(Number(hiddenTotalPrice.value))}` : '—'],
+          ['PayPal Reference', hiddenPayPalCapture.value || hiddenPayPalOrder.value || '—'],
           ['Business', fd.get('business') || '—'],
           ['Address', [fd.get('address'), fd.get('city'), fd.get('postal')].filter(Boolean).join(', ') || '—'],
           ['Preferred Date', fd.get('date') || '—'],
           ['Preferred Time', fd.get('time') || '—'],
-          ['Approx. Sq Ft', fd.get('sqft') || '—'],
-          ['Frequency', freqMap[fd.get('frequency')] || '—'],
-          ['Package', pkgMap[fd.get('package')] || '—'],
-          ['Full Name', fd.get('name') || '—'],
+          ['Full Name', fullName || '—'],
           ['Email', fd.get('email') || '—'],
           ['Phone', fd.get('phone') || '—'],
-          ['Notes', (fd.get('notes') || '—')]
+          ['Notes', fd.get('notes') || '—'],
+          ['Cart Status', hiddenCartStatus && hiddenCartStatus.value === 'added' ? 'Added to cart' : 'Not added yet']
         ];
 
-        reviewList.innerHTML = rows.map(([k,v])=> `<dt>${k}</dt><dd>${String(v).replace(/</g,'&lt;')}</dd>`).join('');
+        reviewList.innerHTML = rows.map(([label, value]) => `<dt>${label}</dt><dd>${String(value)}</dd>`).join('');
       }
 
-      // init
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const method = getSelectedPayment();
+        if(method === 'paypal' && !paypalApproved){
+          setPayPalStatus('Please complete your PayPal deposit before submitting your booking.', 'error');
+          return;
+        }
+
+        if(hiddenCartStatus && hiddenCartStatus.value !== 'added'){
+          if(cartStatus){
+            cartStatus.classList.add('error');
+            cartStatus.textContent = 'Please add the package to your cart before confirming.';
+          }
+          if(addToCartBtn) addToCartBtn.focus();
+          return;
+        }
+
+        const allButtons = form.querySelectorAll('button');
+        allButtons.forEach(btn => btn.disabled = true);
+        if(submitBtn) submitBtn.textContent = 'Sending…';
+
+        syncFullName();
+        const fd = new FormData(form);
+        if(!fd.get('_subject')){
+          fd.append('_subject', 'New Booking Request — Dufferin Deep Clean');
+        }
+
+        const fullName = hiddenFullName ? hiddenFullName.value : [fd.get('first_name'), fd.get('last_name')].filter(Boolean).join(' ');
+        if(fullName){ fd.set('name', fullName); }
+        const freqMapShort = {
+          weekly: 'Weekly (25%)',
+          biweekly: 'Bi-Weekly (20%)',
+          triweekly: 'Tri-Weekly (15%)',
+          monthly: 'Monthly (10%)',
+          biannual: 'Biannual (5%)',
+          onetime: 'One-time'
+        };
+        const summaryLines = [
+          `Service: ${hiddenServiceLabel.value || serviceKey || '—'}`,
+          `Square Footage: ${hiddenSqftLabel.value || fd.get('sqft') || '—'}`,
+          `Details: ${hiddenDetailSummary.value || '—'}`,
+          `Frequency: ${freqMapShort[fd.get('frequency')] || '—'}`,
+          `Cart Status: ${hiddenCartStatus && hiddenCartStatus.value === 'added' ? 'Added to cart' : 'Not added yet'}`,
+          `Base Package: ${hiddenBasePrice.value ? `$${Math.round(Number(hiddenBasePrice.value))}` : '—'}`,
+          `Service Details: ${hiddenDetailPrice.value ? `$${Math.round(Number(hiddenDetailPrice.value))}` : '—'}`,
+          `Add-ons: ${hiddenSelectedAddons.value || 'None'}`,
+          `Add-on Total: ${hiddenAddonsPrice.value ? `$${Math.round(Number(hiddenAddonsPrice.value))}` : '—'}`,
+          `Frequency Savings: ${hiddenDiscountPrice.value && Number(hiddenDiscountPrice.value) ? `-$${Math.round(Number(hiddenDiscountPrice.value))}` : '—'}`,
+          `Deposit Due Today: ${hiddenDepositPrice.value && Number(hiddenDepositPrice.value) ? `$${Math.round(Number(hiddenDepositPrice.value))}` : '—'}`,
+          `Balance at Service: ${hiddenBalancePrice.value && Number(hiddenBalancePrice.value) ? `$${Math.round(Number(hiddenBalancePrice.value))}` : '—'}`,
+          `Estimated Visit Total: ${hiddenTotalPrice.value && Number(hiddenTotalPrice.value) ? `$${Math.round(Number(hiddenTotalPrice.value))}` : '—'}`,
+          `Full Name: ${fullName || '—'}`,
+          `Email: ${fd.get('email') || '—'}`,
+          `Phone: ${fd.get('phone') || '—'}`
+        ];
+
+        if(hiddenPayPalCapture.value || hiddenPayPalOrder.value){
+          summaryLines.push(`PayPal Reference: ${hiddenPayPalCapture.value || hiddenPayPalOrder.value}`);
+        }
+
+        const pricingSummary = summaryLines.join('\n');
+
+        fd.append('pricing_summary', pricingSummary);
+
+        try {
+          const res = await fetch(form.action, {
+            method: 'POST',
+            body: fd,
+            headers: { Accept: 'application/json' }
+          });
+
+          if(res.ok){
+            form.hidden = true;
+            if(layoutEl) layoutEl.hidden = true;
+            if(successEl) successEl.hidden = false;
+          } else {
+            let message = 'There was a problem sending your booking request. Please try again.';
+            try {
+              const data = await res.json();
+              if(data && data.errors && data.errors.length){
+                message = data.errors.map(err => err.message).join('\n');
+              }
+            } catch(_){}
+            alert(message);
+          }
+        } catch(err){
+          alert('Network error. Please check your connection and try again.');
+        } finally {
+          allButtons.forEach(btn => btn.disabled = false);
+          if(submitBtn) submitBtn.textContent = 'Submit';
+        }
+      });
+
+      updateSummary();
+      applyPaymentSelection();
       showStep(0);
     })();
   </script>
-
-  <!-- OPTIONAL: Google Places Autocomplete (shows "Powered by Google" automatically)
-       Replace YOUR_API_KEY_HERE with your Maps JavaScript API key with Places enabled.
-       If you skip this, the form still works—this block is optional. -->
-  <script>
-    (function attachPlaces(){
-      window.initPlaces = function(){
-        if (!window.google || !google.maps || !google.maps.places) return;
-        const addr = document.getElementById('address');
-        if (!addr) return;
-        const ac = new google.maps.places.Autocomplete(addr, {
-          types: ['address'],
-          fields: ['address_components','formatted_address']
-        });
-        ac.addListener('place_changed', () => {
-          const p = ac.getPlace();
-          if (!p || !p.address_components) return;
-          const cityEl = document.getElementById('city');
-          const postalEl = document.getElementById('postal');
-          const comps = p.address_components;
-
-          const get = (type) => (comps.find(c => c.types.includes(type)) || {}).long_name || '';
-          const city = get('locality') || get('postal_town') || get('administrative_area_level_3') || '';
-          const postal = get('postal_code') || '';
-
-          if (city && cityEl) cityEl.value = city;
-          if (postal && postalEl) postalEl.value = postal;
-        });
-      };
-
-      // If developer adds the script later, this still works.
-      // (Do nothing if script isn't present yet.)
-    })();
-  </script>
-  <!-- If you want Places now, uncomment the next line and insert your key:
-  <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY_HERE&libraries=places&callback=initPlaces" async defer></script>
-  -->
 </body>
 </html>
-<!-- BOOKING FORM -->
-<form id="bookingForm"
-      action="https://formspree.io/f/mrblyqpr"
-      method="POST"
-      novalidate>
-
-  <!-- hidden meta sent to Formspree -->
-  <input type="hidden" name="_subject" value="New Booking — DufferinDeepClean">
-  <!-- optional: redirect after success (change URL if you have a thank-you page) -->
-  <input type="hidden" name="_redirect" value="https://dufferindeepclean.ca/thank-you.html">
-  <input type="hidden" name="page" value="book.html">
-
-  <!-- STEP 1 — when & where -->
-  <section class="step" data-step="1">
-    <input name="date" type="date" required>
-    <input name="time" type="time" required>
-    <input name="address" type="text" placeholder="Street address" required>
-    <button type="button" class="next">Next</button>
-  </section>
-
-  <!-- STEP 2 — how often -->
-  <section class="step" data-step="2" hidden>
-    <select name="frequency" required>
-      <option value="">Select frequency</option>
-      <option>One-time</option>
-      <option>Weekly (25% off)</option>
-      <option>Bi-Weekly (20% off)</option>
-      <option>Monthly (10% off)</option>
-      <option>Biannual</option>
-    </select>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 3 — cleaning type -->
-  <section class="step" data-step="3" hidden>
-    <select name="package" required>
-      <option value="">Select a package</option>
-      <option>Specialty Facility Services</option>
-      <option>Office Basic</option>
-      <option>Deep Clean</option>
-    </select>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 4 — your details -->
-  <section class="step" data-step="4" hidden>
-    <input name="full_name" type="text" placeholder="Full name" required>
-    <input name="email" type="email" placeholder="Email" required>
-    <input name="phone" type="tel" placeholder="Phone" required>
-    <textarea name="notes" placeholder="Anything we should know?"></textarea>
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <button type="button" class="next">Next</button>
-    </div>
-  </section>
-
-  <!-- STEP 5 — review & confirm -->
-  <section class="step" data-step="5" hidden>
-    <!-- Optional: render a summary here -->
-    <label class="agree">
-      <input type="checkbox" name="agree" required>
-      I agree to the terms and confirm the details are correct.
-    </label>
-
-    <div class="nav">
-      <button type="button" class="back">Back</button>
-      <!-- IMPORTANT: this must be type="submit" -->
-      <button type="submit" id="submitBtn">Submit</button>
-    </div>
-  </section>
-
-  <!-- inline status messages -->
-  <p id="formStatus" role="status" aria-live="polite" style="display:none;"></p>
-</form>
-
-<script>
-(function() {
-  const steps = [...document.querySelectorAll('.step')];
-  let i = 0;
-  const show = (n) => {
-    steps.forEach((s, idx) => s.hidden = idx !== n);
-    i = n;
-  };
-
-  document.addEventListener('click', (e) => {
-    if (e.target.classList.contains('next')) {
-      const current = steps[i];
-      // simple validation: ensure current step's required inputs are filled
-      const required = current.querySelectorAll('[required]');
-      for (const field of required) {
-        if (!field.checkValidity()) { field.reportValidity(); return; }
-      }
-      show(Math.min(i + 1, steps.length - 1));
-    }
-    if (e.target.classList.contains('back')) show(Math.max(i - 1, 0));
-  });
-
-  // Ajax submit so you can stay on the page and show a message
-  const form = document.getElementById('bookingForm');
-  const status = document.getElementById('formStatus');
-
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault(); // prevent page reload
-
-    // Final validation across the whole form
-    if (!form.checkValidity()) {
-      // report the first invalid input
-      const firstInvalid = form.querySelector(':invalid');
-      if (firstInvalid) firstInvalid.reportValidity();
-      return;
-    }
-
-    const data = new FormData(form);
-    try {
-      const resp = await fetch(form.action, {
-        method: 'POST',
-        body: data,
-        headers: { 'Accept': 'application/json' }
-      });
-
-      if (resp.ok) {
-        status.style.display = 'block';
-        status.textContent = 'Thanks! Your booking request was sent. We’ll email you shortly.';
-        form.reset();
-        show(0); // go back to step 1
-      } else {
-        const err = await resp.json().catch(() => ({}));
-        throw new Error(err.errors?.map(e => e.message).join(', ') || 'Submission failed.');
-      }
-    } catch (err) {
-      status.style.display = 'block';
-      status.textContent = 'Sorry, we could not submit the form. Please try again or email us.';
-      console.error(err);
-    }
-  });
-
-  // start on step 1
-  show(0);
-})();
-</script>

--- a/index.html
+++ b/index.html
@@ -19,11 +19,12 @@
   <!-- Fonts + CSS -->
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Great+Vibes&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
+  <script src="nav-cart.js" defer></script>
 
   <!-- Page-specific tweaks (safe to keep inline) -->
   <style>
     /* keep sections above animated bg from style.css */
-    .navbar, .announcement, .split-screen, .services-page, .about-section, main, section, footer { position:relative; z-index:2; }
+    .navbar, .split-screen, .services-page, .about-section, main, section, footer { position:relative; z-index:2; }
 
     /* Transparent header over infinite bg */
     .navbar{
@@ -52,12 +53,14 @@
       animation: logoSweep 1.1s ease forwards .25s;
     }
 
-    /* Nav links in same script font */
+    /* Nav links typography matches the quote heading */
     .nav-links a{
-      font-family:'Great Vibes', cursive !important;
-      font-size:1.6rem !important;
-      letter-spacing:.02em;
-      color:#f6fbff;
+      font-family:'Inter', sans-serif !important;
+      font-weight:700;
+      text-transform:uppercase;
+      letter-spacing:0.16em;
+      font-size:0.95rem !important;
+      color:#e9f7ff;
     }
 
     /* Hero image flush to right edge */
@@ -65,52 +68,6 @@
       transform:none !important;
       object-position: right center !important;
     }
-
-    /* ===== Rotator card (with slide animations) ===== */
-    .rotator-card{
-      margin-top: 1.25rem;
-      padding: 1.4rem 1.6rem;
-      max-width: 560px;
-      border-radius: 20px;
-      border:1px solid rgba(0,212,255,0.25);
-      background: rgba(0,0,0,0.55);
-      box-shadow: 0 20px 60px rgba(0,0,0,0.45), 0 0 22px rgba(0,212,255,0.12);
-      backdrop-filter: blur(8px);
-      overflow: hidden;
-      position: relative;
-    }
-    .rotator-window{ position:relative; height:auto; min-height: 84px; }
-    .rotator-line{
-      position:absolute; left:0; top:0; width:100%;
-      opacity:0; transform: translateX(24px);
-      transition: transform .45s ease, opacity .45s ease;
-      will-change: transform, opacity;
-    }
-    .rotator-line.active{ opacity:1; transform: translateX(0); }
-    .rotator-title{
-      display:block; font-family:'Bebas Neue',sans-serif; text-transform:uppercase;
-      letter-spacing:.08em; font-size:1.05rem; color:rgba(0,212,255,0.85); margin-bottom:.25rem;
-    }
-    .rotator-text{ display:block; font-size:1.2rem; line-height:1.65; color:#d8ecff; }
-
-    .rotator-underline{
-      display:block; height:3px; width:100%; border-radius:999px; margin-top:.75rem;
-      background:linear-gradient(90deg, rgba(0,212,255,0), rgba(0,212,255,.85), rgba(255,255,255,0));
-      transform-origin:left center; animation: underlineGrow .6s ease both;
-    }
-    @keyframes underlineGrow{ from{ transform:scaleX(0); opacity:.4;} to{ transform:scaleX(1); opacity:1;} }
-
-    .rotator-dots{ display:flex; gap:.5rem; margin-top:.45rem; }
-    .rotator-dots .dot{
-      width:10px; height:10px; border-radius:50%; border:1.5px solid #00d4ff;
-      background:transparent; opacity:.7; cursor:pointer;
-      transition: transform .2s ease, opacity .2s ease, background-color .2s ease;
-    }
-    .rotator-dots .dot.active{ background:#00d4ff; opacity:1; transform:scale(1.05); }
-
-    /* Slight nudge of whole card on change for “box is moving” feel */
-    .rotator-card.bump{ animation: cardBump .35s ease; }
-    @keyframes cardBump{ 0%{ transform:translateX(0);} 40%{ transform:translateX(6px);} 100%{ transform:translateX(0);} }
 
     /* ===== ABOUT (restored) ===== */
     .about-section { padding: 6em 2em 7em; }
@@ -155,49 +112,51 @@
       <a href="#home">Home</a>
       <a href="#services">Services</a>
       <a href="#about">About Us</a>
-      <a href="book.html" class="quote-btn">Book Online</a>
+      <a href="book.html#start" class="quote-btn">Book Online</a>
     </nav>
-  </header>
-
-  <!-- Announcement -->
-  <div class="announcement" role="region" aria-label="Promotion">
-    <div class="announcement-inner">
-      <p class="announce-line">999-999-999</p>
-      <a class="announcement-cta" href="tel:+1999999999">Call Today</a>
+    <div class="nav-actions">
+      <button class="nav-cart" type="button" data-cart-toggle aria-haspopup="dialog" aria-controls="navCartPopover" aria-expanded="false">
+        <span class="nav-cart-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path d="M4.5 4h-2a.5.5 0 0 1 0-1h2.8a1 1 0 0 1 .97.76L6.7 6H21a1 1 0 0 1 .96 1.27l-2 7A1 1 0 0 1 19 15H9.24l-.78 2.34A1 1 0 0 1 7.52 18H4.5a.5.5 0 0 1 0-1h2.55l3.2-9.6L9.8 6H4.78a1 1 0 0 1-.95-.68L4.5 4Zm4.28 3-2.4 7.2H19.1l1.71-6H8.78ZM9 19.75a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Zm9.5 0a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Z" fill="currentColor"/>
+          </svg>
+        </span>
+        <span class="nav-cart-label">Cart</span>
+        <span class="nav-cart-count" data-cart-count hidden>0</span>
+      </button>
     </div>
-  </div>
+  </header>
+  <aside class="nav-cart-popover" id="navCartPopover" role="dialog" aria-modal="false" aria-label="Cart summary" hidden>
+    <div class="nav-cart-popover-inner">
+      <button type="button" class="cart-popover-close" data-cart-close aria-label="Close cart">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <header class="cart-popover-header">
+        <img data-cart-popover-image alt="Cart package preview" loading="lazy" />
+        <div>
+          <p class="cart-popover-title" data-popover-service>Your cart is empty</p>
+          <p class="cart-popover-subtitle" data-popover-frequency>Build a package to see pricing here.</p>
+        </div>
+      </header>
+      <p class="cart-popover-status" data-popover-status hidden></p>
+      <p class="cart-popover-empty" data-popover-empty>Use “Book Online” to customise your cleaning package.</p>
+      <dl class="cart-popover-details" data-popover-details hidden></dl>
+      <div class="cart-popover-totals" data-popover-totals hidden>
+        <div><span>Visit total</span><span data-popover-total>—</span></div>
+        <div><span>Deposit (50%)</span><span data-popover-deposit>—</span></div>
+        <div><span>Balance</span><span data-popover-balance>—</span></div>
+      </div>
+      <div class="cart-popover-payments" data-popover-payments hidden>
+        <div id="nav-paypal-buttons" data-paypal-container="nav"></div>
+        <p class="cart-popover-paypal-status" id="nav-paypal-status" role="status" aria-live="polite"></p>
+        <button type="button" class="btn cart-popover-google" data-google-pay-button disabled>Google Pay (coming soon)</button>
+      </div>
+    </div>
+  </aside>
 
   <!-- HERO -->
   <section id="home" class="split-screen">
     <div class="text-side">
-      <h1 class="headline">
-        <span>We</span> <span>Scrub</span> <span>You</span> <span>Shine</span>
-        <img src="cleanerguy.png" alt="Cleaner" class="headline-image" />
-      </h1>
-
-      <div class="rotator-card" id="service-rotator">
-        <div class="rotator-window" aria-live="polite">
-          <div class="rotator-line active" data-title="Residential Homes">
-            <span class="rotator-title">Residential Homes</span>
-            <span class="rotator-text">We don’t just tidy houses. We deep clean homes.</span>
-          </div>
-          <div class="rotator-line" data-title="Commercial Buildings">
-            <span class="rotator-title">Commercial Buildings</span>
-            <span class="rotator-text">Commercial spaces collect more than dust. We remove it all.</span>
-          </div>
-          <div class="rotator-line" data-title="Offices / Workspaces">
-            <span class="rotator-title">Offices / Workspaces</span>
-            <span class="rotator-text">Clean offices look professional. Deep clean offices stay professional.</span>
-          </div>
-        </div>
-        <span class="rotator-underline" aria-hidden="true"></span>
-        <div class="rotator-dots" role="tablist" aria-label="Service types">
-          <button class="dot active" aria-label="Residential Homes" role="tab"></button>
-          <button class="dot" aria-label="Commercial Buildings" role="tab"></button>
-          <button class="dot" aria-label="Offices / Workspaces" role="tab"></button>
-        </div>
-      </div>
-
       <div id="quote" class="hero-quote" aria-labelledby="quote-title">
         <div class="quote-card">
           <div class="quote-card-header">
@@ -205,7 +164,7 @@
             <p>Answer a few quick questions to unlock a tailored estimate for your space.</p>
           </div>
 
-          <form id="instant-quote" class="quote-form" novalidate>
+          <form id="instant-quote" class="quote-form" data-quote-mode="redirect" data-redirect="book.html" data-redirect-anchor="start" novalidate>
             <div class="quote-grid">
               <label class="field" for="quote-first-name">
                 <span class="field-label">First Name</span>
@@ -217,174 +176,136 @@
                 <input id="quote-email" name="email" type="email" placeholder="you@example.com" autocomplete="email" data-required>
               </label>
 
-              <label class="field" for="quote-service">
-                <span class="field-label">Type of Cleaning Service</span>
-                <select id="quote-service" name="service" data-required>
-                  <option value="" disabled selected>Select a service</option>
-                  <option value="home">Home General Cleaning</option>
-                  <option value="commercial">Factory / Commercial / Industrial Cleaning</option>
-                  <option value="office">Office Workspace Cleaning</option>
-                </select>
+              <label class="field field-inline" for="quote-service">
+                <span class="field-label">Type of Service</span>
+                <div class="select-wrap">
+                  <select id="quote-service" name="service" data-required>
+                    <option value="" disabled selected>Select a service</option>
+                    <option value="home">Home General Cleaning</option>
+                    <option value="commercial">Factory / Commercial / Industrial Cleaning</option>
+                    <option value="office">Office Workspace Cleaning</option>
+                  </select>
+                </div>
               </label>
 
-              <label class="field" for="quote-square-footage">
+              <label class="field field-inline" for="quote-sqft">
                 <span class="field-label">Square Footage</span>
-                <select id="quote-square-footage" name="square-footage" data-required>
-                  <option value="" disabled selected>Select the range</option>
-                  <option value="1000-1500">1,000 – 1,500 sq ft</option>
-                  <option value="1500-2000">1,500 – 2,000 sq ft</option>
-                  <option value="2000-2500">2,000 – 2,500 sq ft</option>
-                  <option value="2500-3000">2,500 – 3,000 sq ft</option>
-                  <option value="3000-3500">3,000 – 3,500 sq ft</option>
-                  <option value="3500-4000">3,500 – 4,000 sq ft</option>
-                </select>
+                <div class="select-wrap">
+                  <select id="quote-sqft" name="square-footage" data-required>
+                    <option value="" disabled selected>Select an approximate size</option>
+                    <option value="1000-1500">1,000 – 1,500 sq ft</option>
+                    <option value="1500-2000">1,500 – 2,000 sq ft</option>
+                    <option value="2000-2500">2,000 – 2,500 sq ft</option>
+                    <option value="2500-3000">2,500 – 3,000 sq ft</option>
+                    <option value="3000-3500">3,000 – 3,500 sq ft</option>
+                    <option value="3500-4000">3,500 – 4,000 sq ft</option>
+                  </select>
+                </div>
               </label>
+            </div>
+
+            <div id="service-details" class="service-details" aria-live="polite">
+              <div class="service-detail-group detail-inline" data-service-detail="home" aria-hidden="true">
+                <label class="detail-inline-field" for="home-rooms">
+                  <span class="detail-card-label">Number of bedrooms</span>
+                  <div class="number-wrap">
+                    <button type="button" class="stepper-button" data-step="-1" aria-label="Decrease bedrooms" aria-controls="home-rooms"><span aria-hidden="true">−</span></button>
+                    <input id="home-rooms" name="home-rooms" type="number" min="1" max="12" step="1" inputmode="numeric" placeholder="0" data-required data-service-required="home" data-label-prefix="bedroom" data-label-plural="bedrooms" data-detail-key="homeRooms">
+                    <button type="button" class="stepper-button" data-step="1" aria-label="Increase bedrooms" aria-controls="home-rooms"><span aria-hidden="true">+</span></button>
+                  </div>
+                </label>
+                <label class="detail-inline-field" for="home-bathrooms">
+                  <span class="detail-card-label">Number of bathrooms</span>
+                  <div class="number-wrap">
+                    <button type="button" class="stepper-button" data-step="-1" aria-label="Decrease bathrooms" aria-controls="home-bathrooms"><span aria-hidden="true">−</span></button>
+                    <input id="home-bathrooms" name="home-bathrooms" type="number" min="1" max="10" step="1" inputmode="numeric" placeholder="0" data-required data-service-required="home" data-label-prefix="bathroom" data-label-plural="bathrooms" data-detail-key="homeBathrooms">
+                    <button type="button" class="stepper-button" data-step="1" aria-label="Increase bathrooms" aria-controls="home-bathrooms"><span aria-hidden="true">+</span></button>
+                  </div>
+                </label>
+                <div class="detail-inline-field detail-inline-pets" data-detail-pets>
+                  <span class="detail-card-label">Pets on site?</span>
+                  <input type="hidden" name="home-pets" data-required data-service-required="home">
+                  <div class="mini-pill-group tight" role="radiogroup" aria-label="Are there pets?">
+                    <button type="button" class="mini-pill" data-target-input="home-pets" data-value="no" data-label="No pets">No</button>
+                    <button type="button" class="mini-pill" data-target-input="home-pets" data-value="yes" data-label="Yes, pets">Yes</button>
+                  </div>
+                </div>
+                <div class="detail-inline-field detail-inline-basement" data-detail-basement>
+                  <span class="detail-card-label">Basement?</span>
+                  <input type="hidden" name="home-basement" data-required data-service-required="home">
+                  <div class="mini-pill-group tight" role="radiogroup" aria-label="Is a basement included?">
+                    <button type="button" class="mini-pill" data-target-input="home-basement" data-value="no" data-label="No basement">No</button>
+                    <button type="button" class="mini-pill" data-target-input="home-basement" data-value="yes" data-label="Basement included">Yes</button>
+                  </div>
+                </div>
+                <div class="detail-basement-extra" data-basement-extra hidden aria-hidden="true">
+                  <label class="detail-inline-field" for="home-basement-rooms">
+                    <span class="detail-card-label">Basement rooms</span>
+                    <div class="number-wrap">
+                      <button type="button" class="stepper-button" data-step="-1" aria-label="Decrease basement rooms" aria-controls="home-basement-rooms"><span aria-hidden="true">−</span></button>
+                      <input id="home-basement-rooms" name="home-basement-rooms" type="number" min="1" max="8" step="1" inputmode="numeric" placeholder="0" data-required data-service-required="home" data-dependent-on="home-basement" data-dependent-value="yes" data-label-prefix="basement room" data-label-plural="basement rooms" data-detail-key="homeBasementRooms">
+                      <button type="button" class="stepper-button" data-step="1" aria-label="Increase basement rooms" aria-controls="home-basement-rooms"><span aria-hidden="true">+</span></button>
+                    </div>
+                  </label>
+                  <label class="detail-inline-field" for="home-basement-bathrooms">
+                    <span class="detail-card-label">Basement bathrooms</span>
+                    <div class="number-wrap">
+                      <button type="button" class="stepper-button" data-step="-1" aria-label="Decrease basement bathrooms" aria-controls="home-basement-bathrooms"><span aria-hidden="true">−</span></button>
+                      <input id="home-basement-bathrooms" name="home-basement-bathrooms" type="number" min="1" max="4" step="1" inputmode="numeric" placeholder="0" data-required data-service-required="home" data-dependent-on="home-basement" data-dependent-value="yes" data-label-prefix="basement bathroom" data-label-plural="basement bathrooms" data-detail-key="homeBasementBathrooms">
+                      <button type="button" class="stepper-button" data-step="1" aria-label="Increase basement bathrooms" aria-controls="home-basement-bathrooms"><span aria-hidden="true">+</span></button>
+                    </div>
+                  </label>
+                </div>
+              </div>
+
+              <div class="service-detail-group" data-service-detail="office" aria-hidden="true">
+                <p class="service-detail-title">Office Workspace Details</p>
+                <div class="detail-card-grid">
+                  <div class="detail-card">
+                    <span class="detail-card-label">Number of Offices</span>
+                    <input type="hidden" name="office-offices" data-required data-service-required="office">
+                    <div class="mini-pill-group tight" role="radiogroup" aria-label="Number of offices">
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="1-5" data-label="1 – 5 offices">1–5</button>
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="6-10" data-label="6 – 10 offices">6–10</button>
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="11-20" data-label="11 – 20 offices">11–20</button>
+                      <button type="button" class="mini-pill" data-target-input="office-offices" data-value="21+" data-label="21+ offices">21+</button>
+                    </div>
+                  </div>
+                  <div class="detail-card">
+                    <span class="detail-card-label">Number of Bathrooms</span>
+                    <input type="hidden" name="office-bathrooms" data-required data-service-required="office">
+                    <div class="mini-pill-group tight" role="radiogroup" aria-label="Number of bathrooms">
+                      <button type="button" class="mini-pill" data-target-input="office-bathrooms" data-value="1-2" data-label="1 – 2 bathrooms">1–2</button>
+                      <button type="button" class="mini-pill" data-target-input="office-bathrooms" data-value="3-4" data-label="3 – 4 bathrooms">3–4</button>
+                      <button type="button" class="mini-pill" data-target-input="office-bathrooms" data-value="5+" data-label="5+ bathrooms">5+</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div class="quote-summary" aria-live="polite">
               <div class="quote-summary-line">
-                <span>Base Estimate</span>
-                <strong id="quote-base-price">—</strong>
+                <span>Base Package</span>
+                <strong data-quote-base>—</strong>
+              </div>
+              <div class="quote-summary-line" data-quote-detail-row hidden>
+                <span>Service Details</span>
+                <strong data-quote-detail>—</strong>
               </div>
               <div class="quote-summary-line total">
-                <span>Total with Customizations</span>
-                <strong id="quote-total-price">—</strong>
+                <span>Estimated Visit Total</span>
+                <strong data-quote-total>—</strong>
               </div>
             </div>
 
-            <div id="quote-customize" class="quote-customize" aria-hidden="true">
-              <div class="customize-heading" role="status">Customize your cleaning</div>
-
-              <div class="addon-groups">
-                <div class="addon-group" data-service-group="home">
-                  <p class="addon-group-title">Home &amp; Residential Extras</p>
-                  <div class="addon-pill color-cyan" data-addon="Deep Clean Package" data-price="80">
-                    <span class="addon-icon">✨</span>
-                    <span class="addon-name">Deep Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Deep Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-lime" data-addon="Move In/Out Clean Package" data-price="95">
-                    <span class="addon-icon">🚚</span>
-                    <span class="addon-name">Move In/Out Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-magenta" data-addon="Renovation Clean Package" data-price="110">
-                    <span class="addon-icon">🛠️</span>
-                    <span class="addon-name">Renovation Clean Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Renovation Clean Package quantity">
-                  </div>
-                  <div class="addon-pill color-orange" data-addon="Move In/Out Package (Student Property)" data-price="70">
-                    <span class="addon-icon">🎓</span>
-                    <span class="addon-name">Move In/Out Package (Student Property)</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Move In/Out Package (Student Property) quantity">
-                  </div>
-                  <div class="addon-pill color-indigo" data-addon="AirBnB Listing" data-price="65">
-                    <span class="addon-icon">🏠</span>
-                    <span class="addon-name">AirBnB Listing</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="AirBnB Listing quantity">
-                  </div>
-                  <div class="addon-pill color-gold" data-addon="I have Pets" data-price="35">
-                    <span class="addon-icon">🐾</span>
-                    <span class="addon-name">I have Pets</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="I have Pets quantity">
-                  </div>
-                  <div class="addon-pill color-sky" data-addon="Inside Fridge" data-price="25">
-                    <span class="addon-icon">🧊</span>
-                    <span class="addon-name">Inside Fridge</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Fridge quantity">
-                  </div>
-                  <div class="addon-pill color-rose" data-addon="Inside Oven" data-price="25">
-                    <span class="addon-icon">🔥</span>
-                    <span class="addon-name">Inside Oven</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Oven quantity">
-                  </div>
-                  <div class="addon-pill color-mint" data-addon="Inside Cabinets" data-price="30">
-                    <span class="addon-icon">🗄️</span>
-                    <span class="addon-name">Inside Cabinets</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Inside Cabinets quantity">
-                  </div>
-                  <div class="addon-pill color-teal" data-addon="Additional Kitchen" data-price="45">
-                    <span class="addon-icon">🍽️</span>
-                    <span class="addon-name">Additional Kitchen</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Additional Kitchen quantity">
-                  </div>
-                  <div class="addon-pill color-plum" data-addon="Blinds (per window)" data-price="8">
-                    <span class="addon-icon">🪟</span>
-                    <span class="addon-name">Blinds (per window)</span>
-                    <input class="addon-qty" type="number" min="1" max="25" value="1" aria-label="Blinds quantity">
-                  </div>
-                  <div class="addon-pill color-azure" data-addon="Inside Windows with Tracks (up to 6)" data-price="60">
-                    <span class="addon-icon">🔍</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 6)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 6 quantity">
-                  </div>
-                  <div class="addon-pill color-amber" data-addon="Inside Windows with Tracks (up to 12)" data-price="105">
-                    <span class="addon-icon">🔎</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 12)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 12 quantity">
-                  </div>
-                  <div class="addon-pill color-blue" data-addon="Inside Windows with Tracks (up to 24)" data-price="195">
-                    <span class="addon-icon">🪟</span>
-                    <span class="addon-name">Inside Windows with Tracks (up to 24)</span>
-                    <input class="addon-qty" type="number" min="1" max="5" value="1" aria-label="Inside Windows with Tracks up to 24 quantity">
-                  </div>
-                  <div class="addon-pill color-lavender" data-addon="Change Bed Sheets + Load Laundry" data-price="18">
-                    <span class="addon-icon">🛏️</span>
-                    <span class="addon-name">Change Bed Sheets + Load Laundry</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Change Bed Sheets quantity">
-                  </div>
-                  <div class="addon-pill color-crimson" data-addon="Load dishwasher" data-price="10">
-                    <span class="addon-icon">🍽️</span>
-                    <span class="addon-name">Load Dishwasher</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Load Dishwasher quantity">
-                  </div>
-                  <div class="addon-pill color-emerald" data-addon="Sanitization Package" data-price="55">
-                    <span class="addon-icon">🧴</span>
-                    <span class="addon-name">Sanitization Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Sanitization Package quantity">
-                  </div>
-                </div>
-
-                <div class="addon-group" data-service-group="commercial,office">
-                  <p class="addon-group-title">Facility &amp; Workspace Enhancements</p>
-                  <div class="addon-pill color-indigo" data-addon="Carpet Steam Cleaning Package" data-price="140">
-                    <span class="addon-icon">🧼</span>
-                    <span class="addon-name">Carpet Steam Cleaning Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Carpet Steam Cleaning quantity">
-                  </div>
-                  <div class="addon-pill color-azure" data-addon="Tile and Grout Cleaning Package" data-price="130">
-                    <span class="addon-icon">🧽</span>
-                    <span class="addon-name">Tile and Grout Cleaning Package</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Tile and Grout Cleaning quantity">
-                  </div>
-                  <div class="addon-pill color-mint" data-addon="Restock Bathroom Supply" data-price="40">
-                    <span class="addon-icon">🧻</span>
-                    <span class="addon-name">Restock Bathroom Supply</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Restock Bathroom Supply quantity">
-                  </div>
-                  <div class="addon-pill color-gold" data-addon="Disinfect Electronics" data-price="45">
-                    <span class="addon-icon">💻</span>
-                    <span class="addon-name">Disinfect Electronics</span>
-                    <input class="addon-qty" type="number" min="1" max="10" value="1" aria-label="Disinfect Electronics quantity">
-                  </div>
-                  <div class="addon-pill color-teal" data-addon="Empty Garbage/Recycling" data-price="18">
-                    <span class="addon-icon">🗑️</span>
-                    <span class="addon-name">Empty Garbage/Recycling</span>
-                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Empty Garbage/Recycling quantity">
-                  </div>
-                  <div class="addon-pill color-lime" data-addon="Water Plants" data-price="15">
-                    <span class="addon-icon">🌿</span>
-                    <span class="addon-name">Water Plants</span>
-                    <input class="addon-qty" type="number" min="1" max="20" value="1" aria-label="Water Plants quantity">
-                  </div>
-                </div>
-              </div>
+            <div class="quote-actions">
+              <button type="button" id="quote-see-price" class="quote-see-price" disabled>See My Price</button>
             </div>
           </form>
         </div>
       </div>
 
-      <a href="tel:+1999999999" class="quote-btn-home">Call Now</a>
       <a href="#services" class="services-btn-home">Our Services</a>
     </div>
 
@@ -466,17 +387,8 @@
   <!-- Quote logic -->
   <script>
     (function(){
-      const form = document.getElementById('instant-quote');
-      if(!form) return;
-
-      const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
-      const basePriceEl = document.getElementById('quote-base-price');
-      const totalPriceEl = document.getElementById('quote-total-price');
-      const customizeBlock = document.getElementById('quote-customize');
-      const serviceSelect = document.getElementById('quote-service');
-      const sqftSelect = document.getElementById('quote-square-footage');
-      const addonGroups = Array.from(form.querySelectorAll('.addon-group'));
-      const addonPills = Array.from(form.querySelectorAll('.addon-pill'));
+      const quoteForms = Array.from(document.querySelectorAll('form.quote-form'));
+      if(!quoteForms.length) return;
 
       const basePricing = {
         home: {
@@ -505,146 +417,560 @@
         }
       };
 
-      function hasAllRequired(){
-        return requiredFields.every(field => {
-          if(field.type === 'email'){
-            return field.value.trim() !== '' && field.value.includes('@');
-          }
-          return field.value.trim() !== '';
-        });
-      }
+      const detailPricing = {
+        home: {
+          rooms: { '1-2': 0, '3-4': 25, '5-6': 55, '7+': 85 },
+          bathrooms: { '1': 0, '2': 18, '3': 36, '4+': 54 },
+          pets: { no: 0, yes: 25 },
+          basement: { no: 0, yes: 45 },
+          basementRooms: { '1-2': 25, '3-4': 45, '5+': 65 },
+          basementBathrooms: { '1': 18, '2': 32, '3+': 46 }
+        },
+        office: {
+          offices: { '1-5': 0, '6-10': 45, '11-20': 90, '21+': 135 },
+          bathrooms: { '1-2': 0, '3-4': 40, '5+': 70 }
+        }
+      };
 
-      function resetAddons(){
-        addonPills.forEach(pill => {
-          pill.classList.remove('active');
-          const qty = pill.querySelector('.addon-qty');
-          if(qty){
-            qty.value = 1;
-            qty.disabled = true;
-          }
-          pill.setAttribute('aria-pressed', 'false');
-        });
-      }
+      quoteForms.forEach(setupQuoteForm);
 
-      function updateAddonAvailability(serviceKey){
-        addonGroups.forEach(group => {
-          const services = group.dataset.serviceGroup.split(',');
-          const match = services.includes(serviceKey);
-          group.classList.toggle('active', match);
-        });
+      function setupQuoteForm(form){
+        const requiredFields = Array.from(form.querySelectorAll('[data-required]'));
+        const basePriceEl = form.querySelector('[data-quote-base]');
+        const detailRow = form.querySelector('[data-quote-detail-row]');
+        const detailPriceEl = form.querySelector('[data-quote-detail]');
+        const totalPriceEl = form.querySelector('[data-quote-total]');
+        const serviceInput = form.querySelector('[name="service"]');
+        const sqftInput = form.querySelector('[name="square-footage"]');
+        const serviceDetailsWrapper = form.querySelector('.service-details');
+        const detailGroups = serviceDetailsWrapper ? Array.from(serviceDetailsWrapper.querySelectorAll('[data-service-detail]')) : [];
+        const seePriceBtn = form.querySelector('.quote-see-price');
+        const pillControls = Array.from(form.querySelectorAll('[data-target-input]'));
+        const numberFields = Array.from(form.querySelectorAll('input[type="number"][data-detail-key]'));
 
-        addonPills.forEach(pill => {
-          const parent = pill.closest('.addon-group');
-          const enabled = parent && parent.classList.contains('active');
-          pill.style.display = enabled ? '' : 'none';
-          if(!enabled){
-            pill.classList.remove('active');
-            const qty = pill.querySelector('.addon-qty');
-            if(qty){
-              qty.value = 1;
-              qty.disabled = true;
-            }
-            pill.setAttribute('aria-pressed', 'false');
-          }
-        });
-      }
-
-      function calculateTotal(){
-        const serviceKey = serviceSelect.value;
-        const sqftKey = sqftSelect.value;
-        if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
-          basePriceEl.textContent = '—';
-          totalPriceEl.textContent = '—';
-          return;
+        function adjustNumericInput(input, delta){
+          if(!input || !Number.isFinite(delta)) return;
+          const step = Number(input.step || 1) || 1;
+          const min = input.min !== '' ? Number(input.min) : null;
+          const max = input.max !== '' ? Number(input.max) : null;
+          const currentValue = input.value === '' ? null : Number(input.value);
+          let next = Number.isFinite(currentValue) ? currentValue + delta * step : (min !== null ? min : step);
+          if(min !== null && Number.isFinite(min)) next = Math.max(next, min);
+          if(max !== null && Number.isFinite(max)) next = Math.min(next, max);
+          if(!Number.isFinite(next)) next = min !== null ? min : step;
+          input.value = String(next);
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+          input.dispatchEvent(new Event('change', { bubbles: true }));
         }
 
-        const base = basePricing[serviceKey][sqftKey] || 0;
-        let total = base;
-
-        addonPills.forEach(pill => {
-          if(!pill.classList.contains('active')) return;
-          const parent = pill.closest('.addon-group');
-          if(!parent || !parent.classList.contains('active')) return;
-
-          const price = Number(pill.dataset.price || 0);
-          const qtyInput = pill.querySelector('.addon-qty');
-          const qty = qtyInput ? Math.max(1, Number(qtyInput.value) || 1) : 1;
-          total += price * qty;
-        });
-
-        basePriceEl.textContent = base ? `$${base.toFixed(0)}` : '—';
-        totalPriceEl.textContent = total ? `$${total.toFixed(0)}` : '—';
-      }
-
-      function toggleCustomize(){
-        const ready = hasAllRequired();
-        customizeBlock.classList.toggle('visible', ready);
-        customizeBlock.setAttribute('aria-hidden', ready ? 'false' : 'true');
-        form.classList.toggle('quote-ready', ready);
-        if(!ready){
-          basePriceEl.textContent = '—';
-          totalPriceEl.textContent = '—';
-          resetAddons();
-        } else {
-          updateAddonAvailability(serviceSelect.value);
-          calculateTotal();
+        function wireNumberSteppers(){
+          const wrappers = Array.from(form.querySelectorAll('.number-wrap'));
+          wrappers.forEach(wrapper => {
+            const input = wrapper.querySelector('input[type="number"]');
+            if(!input) return;
+            wrapper.querySelectorAll('.stepper-button').forEach(button => {
+              button.addEventListener('click', (event) => {
+                event.preventDefault();
+                const delta = Number(button.dataset.step || 0);
+                if(!delta) return;
+                adjustNumericInput(input, delta);
+              });
+            });
+          });
         }
-      }
+        const basementField = form.querySelector('[name="home-basement"]');
+        const basementExtras = form.querySelector('[data-basement-extra]');
+        const basementExtraNumbers = basementExtras ? Array.from(basementExtras.querySelectorAll('input[type="number"]')) : [];
+        const basementRoomsField = form.querySelector('[name="home-basement-rooms"]');
+        const basementBathsField = form.querySelector('[name="home-basement-bathrooms"]');
 
-      addonPills.forEach(pill => {
-        pill.addEventListener('click', (event) => {
-          if(!customizeBlock.classList.contains('visible')) return;
-          const qtyInput = pill.querySelector('.addon-qty');
-          if(event.target === qtyInput) return;
+        function formatCountLabel(count, input){
+          if(!input) return `${count}`;
+          const singular = input.dataset.labelPrefix || '';
+          if(!singular) return `${count}`;
+          const plural = input.dataset.labelPlural;
+          const fallbackPlural = plural || (singular.endsWith('s') ? `${singular}es` : `${singular}s`);
+          const word = count === 1 ? singular : (plural || fallbackPlural);
+          return `${count} ${word}`;
+        }
 
-          pill.classList.toggle('active');
-          if(qtyInput){
-            qtyInput.disabled = !pill.classList.contains('active');
+        function mapHomeRooms(count, input){
+          const label = formatCountLabel(count, input);
+          if(count <= 2) return { key: '1-2', label };
+          if(count <= 4) return { key: '3-4', label };
+          if(count <= 6) return { key: '5-6', label };
+          return { key: '7+', label };
+        }
+
+        function mapHomeBathrooms(count, input){
+          const label = formatCountLabel(count, input);
+          if(count <= 1) return { key: '1', label };
+          if(count <= 2) return { key: '2', label };
+          if(count <= 3) return { key: '3', label };
+          return { key: '4+', label };
+        }
+
+        function mapBasementRooms(count, input){
+          const label = formatCountLabel(count, input);
+          if(count <= 2) return { key: '1-2', label };
+          if(count <= 4) return { key: '3-4', label };
+          return { key: '5+', label };
+        }
+
+        function mapBasementBathrooms(count, input){
+          const label = formatCountLabel(count, input);
+          if(count <= 1) return { key: '1', label };
+          if(count <= 2) return { key: '2', label };
+          return { key: '3+', label };
+        }
+
+        function detailMapperFor(input){
+          if(!input) return null;
+          const key = input.dataset.detailKey;
+          if(key === 'homeRooms') return mapHomeRooms;
+          if(key === 'homeBathrooms') return mapHomeBathrooms;
+          if(key === 'homeBasementRooms') return mapBasementRooms;
+          if(key === 'homeBasementBathrooms') return mapBasementBathrooms;
+          return null;
+        }
+
+        function updateNumberMeta(input){
+          if(!input) return;
+          const raw = input.value ? input.value.trim() : '';
+          if(!raw){
+            input.dataset.label = '';
+            input.dataset.pricingKey = '';
+            return;
           }
-          pill.setAttribute('aria-pressed', pill.classList.contains('active') ? 'true' : 'false');
-          calculateTotal();
-        });
+          const count = Number(raw);
+          if(!Number.isFinite(count) || count <= 0){
+            input.dataset.label = '';
+            input.dataset.pricingKey = '';
+            return;
+          }
+          const mapper = detailMapperFor(input);
+          const mapping = mapper ? mapper(count, input) : null;
+          if(mapping){
+            input.dataset.label = mapping.label;
+            input.dataset.pricingKey = mapping.key || '';
+          } else {
+            input.dataset.label = formatCountLabel(count, input);
+            input.dataset.pricingKey = '';
+          }
+        }
 
-        const qtyInput = pill.querySelector('.addon-qty');
-        if(qtyInput){
-          qtyInput.disabled = true;
-          qtyInput.addEventListener('input', () => {
-            if(!pill.classList.contains('active')) return;
-            if(qtyInput.value === '' || Number(qtyInput.value) < Number(qtyInput.min)){
-              qtyInput.value = qtyInput.min;
+        function numberSelection(input){
+          if(!input) return null;
+          updateNumberMeta(input);
+          const raw = input.value ? input.value.trim() : '';
+          if(!raw) return null;
+          const count = Number(raw);
+          if(!Number.isFinite(count) || count <= 0) return null;
+          const label = input.dataset.label || formatCountLabel(count, input);
+          const key = input.dataset.pricingKey || '';
+          return { value: raw, label, key };
+        }
+
+        function dependencySatisfied(field){
+          const dependencyName = field.dataset.dependentOn;
+          if(!dependencyName) return true;
+          const dependencyField = form.querySelector(`[name="${dependencyName}"]`);
+          if(!dependencyField) return false;
+          const expected = (field.dataset.dependentValue || '').split(',').map(val => val.trim()).filter(Boolean);
+          const actual = dependencyField.value || '';
+          if(expected.length){
+            return expected.includes(actual);
+          }
+          return actual !== '';
+        }
+
+        function fieldIsRelevant(field){
+          const requirement = field.dataset.serviceRequired;
+          if(requirement){
+            const serviceKey = serviceInput ? serviceInput.value : '';
+            if(!serviceKey) return false;
+            if(!requirement.split(',').includes(serviceKey)) return false;
+          }
+          return dependencySatisfied(field);
+        }
+
+        function hasAllRequired(){
+          return requiredFields.every(field => {
+            if(!fieldIsRelevant(field)) return true;
+            const value = field.value ? field.value.trim() : '';
+            if(field.type === 'email'){
+              return value !== '' && value.includes('@');
             }
-            calculateTotal();
+            if(field.type === 'number'){
+              if(value === '') return false;
+              const numeric = Number(value);
+              if(!Number.isFinite(numeric) || numeric <= 0) return false;
+              if(field.min !== '' && !Number.isNaN(Number(field.min)) && numeric < Number(field.min)) return false;
+              return true;
+            }
+            return value !== '';
           });
         }
 
-        pill.addEventListener('keydown', (evt) => {
-          if(evt.key === 'Enter' || evt.key === ' '){
-            evt.preventDefault();
-            pill.click();
+        function resetServiceGroup(group){
+          const hiddenInputs = Array.from(group.querySelectorAll('input[type="hidden"]'));
+          hiddenInputs.forEach(input => {
+            input.value = '';
+            input.dataset.label = '';
+          });
+          const selects = Array.from(group.querySelectorAll('select'));
+          selects.forEach(select => {
+            select.selectedIndex = 0;
+          });
+          const numbers = Array.from(group.querySelectorAll('input[type="number"]'));
+          numbers.forEach(input => {
+            input.value = '';
+            input.dataset.label = '';
+            input.dataset.pricingKey = '';
+          });
+          const buttons = Array.from(group.querySelectorAll('[data-target-input]'));
+          buttons.forEach(btn => {
+            btn.classList.remove('active');
+            btn.setAttribute('aria-pressed', 'false');
+          });
+          const basementExtras = Array.from(group.querySelectorAll('[data-basement-extra]'));
+          basementExtras.forEach(extra => {
+            extra.hidden = true;
+            extra.classList.remove('visible');
+            extra.setAttribute('aria-hidden', 'true');
+          });
+        }
+
+        function updateServiceDetails(serviceKey){
+          if(!serviceDetailsWrapper) return;
+          let activeCount = 0;
+          detailGroups.forEach(group => {
+            const services = (group.dataset.serviceDetail || '').split(',');
+            const match = serviceKey && services.includes(serviceKey);
+            group.classList.toggle('active', !!match);
+            group.setAttribute('aria-hidden', match ? 'false' : 'true');
+            if(match){
+              activeCount += 1;
+            } else {
+              resetServiceGroup(group);
+            }
+          });
+          serviceDetailsWrapper.classList.toggle('visible', activeCount > 0);
+          serviceDetailsWrapper.setAttribute('aria-hidden', activeCount > 0 ? 'false' : 'true');
+          syncBasementExtras(serviceKey);
+        }
+
+        function setBasementExtrasVisible(show){
+          if(!basementExtras) return;
+          if(show){
+            basementExtras.hidden = false;
+            basementExtras.classList.add('visible');
+            basementExtras.setAttribute('aria-hidden', 'false');
+            basementExtraNumbers.forEach(updateNumberMeta);
+          } else {
+            basementExtras.hidden = true;
+            basementExtras.classList.remove('visible');
+            basementExtras.setAttribute('aria-hidden', 'true');
+            basementExtraNumbers.forEach(input => {
+              input.value = '';
+              input.dataset.label = '';
+              input.dataset.pricingKey = '';
+              updateNumberMeta(input);
+            });
           }
+        }
+
+        function syncBasementExtras(serviceKey){
+          if(!basementField){
+            setBasementExtrasVisible(false);
+            return;
+          }
+          const shouldShow = serviceKey === 'home' && basementField.value === 'yes';
+          setBasementExtrasVisible(shouldShow);
+        }
+
+        function selectionInfo(input){
+          if(!input || !input.value) return null;
+          return {
+            value: input.value,
+            label: resolveLabel(input)
+          };
+        }
+
+        function resolveLabel(input){
+          if(!input) return '';
+          if(input.tagName === 'SELECT'){
+            const option = input.options[input.selectedIndex];
+            if(option){
+              return option.dataset.label || option.textContent.trim();
+            }
+            return '';
+          }
+          if(input.dataset && input.dataset.label){
+            return input.dataset.label;
+          }
+          return input.value || '';
+        }
+
+        function calculateTotals(){
+          const serviceKey = serviceInput ? serviceInput.value : '';
+          const sqftKey = sqftInput ? sqftInput.value : '';
+          if(!serviceKey || !sqftKey || !basePricing[serviceKey]){
+            return { ready: false, base: 0, detail: 0, total: 0, selections: {}, serviceLabel: '', sqftLabel: '' };
+          }
+
+          const base = basePricing[serviceKey][sqftKey] || 0;
+          let detailAdjustment = 0;
+          const selections = {};
+
+          if(serviceKey === 'home'){
+            const roomsField = form.querySelector('[name="home-rooms"]');
+            const bathsField = form.querySelector('[name="home-bathrooms"]');
+            const petsField = form.querySelector('[name="home-pets"]');
+
+            const roomsInfo = numberSelection(roomsField);
+            const bathsInfo = numberSelection(bathsField);
+            const petsInfo = selectionInfo(petsField);
+            const basementInfo = selectionInfo(basementField);
+            const basementRoomsInfo = basementInfo && basementInfo.value === 'yes' ? numberSelection(basementRoomsField) : null;
+            const basementBathsInfo = basementInfo && basementInfo.value === 'yes' ? numberSelection(basementBathsField) : null;
+
+            if(roomsInfo){
+              if(roomsInfo.key){ detailAdjustment += detailPricing.home.rooms[roomsInfo.key] || 0; }
+              selections.homeRooms = { value: roomsInfo.value, label: roomsInfo.label };
+            }
+            if(bathsInfo){
+              if(bathsInfo.key){ detailAdjustment += detailPricing.home.bathrooms[bathsInfo.key] || 0; }
+              selections.homeBathrooms = { value: bathsInfo.value, label: bathsInfo.label };
+            }
+            if(petsInfo){
+              detailAdjustment += detailPricing.home.pets[petsInfo.value] || 0;
+              selections.homePets = petsInfo;
+            }
+            if(basementInfo){
+              const basementPricing = detailPricing.home.basement || {};
+              if(Object.prototype.hasOwnProperty.call(basementPricing, basementInfo.value)){
+                detailAdjustment += basementPricing[basementInfo.value] || 0;
+              }
+              selections.homeBasement = basementInfo;
+            }
+            if(basementRoomsInfo){
+              if(basementRoomsInfo.key){ detailAdjustment += detailPricing.home.basementRooms[basementRoomsInfo.key] || 0; }
+              selections.homeBasementRooms = { value: basementRoomsInfo.value, label: basementRoomsInfo.label };
+            }
+            if(basementBathsInfo){
+              if(basementBathsInfo.key){ detailAdjustment += detailPricing.home.basementBathrooms[basementBathsInfo.key] || 0; }
+              selections.homeBasementBathrooms = { value: basementBathsInfo.value, label: basementBathsInfo.label };
+            }
+          }
+
+          if(serviceKey === 'office'){
+            const officesField = form.querySelector('[name="office-offices"]');
+            const officeBathsField = form.querySelector('[name="office-bathrooms"]');
+
+            const officesInfo = selectionInfo(officesField);
+            const officeBathsInfo = selectionInfo(officeBathsField);
+
+            if(officesInfo){
+              detailAdjustment += detailPricing.office.offices[officesInfo.value] || 0;
+              selections.officeOffices = officesInfo;
+            }
+            if(officeBathsInfo){
+              detailAdjustment += detailPricing.office.bathrooms[officeBathsInfo.value] || 0;
+              selections.officeBathrooms = officeBathsInfo;
+            }
+          }
+
+          return {
+            ready: true,
+            base,
+            detail: detailAdjustment,
+            total: base + detailAdjustment,
+            selections,
+            serviceLabel: resolveLabel(serviceInput) || serviceKey,
+            sqftLabel: resolveLabel(sqftInput) || sqftKey
+          };
+        }
+
+        function formatCurrency(value){
+          if(!value) return '—';
+          return `$${Math.round(value)}`;
+        }
+
+        function updateTotals(){
+          const totals = calculateTotals();
+
+          if(basePriceEl){ basePriceEl.textContent = totals.ready ? formatCurrency(totals.base) : '—'; }
+          if(totalPriceEl){ totalPriceEl.textContent = totals.ready ? formatCurrency(totals.total) : '—'; }
+
+          if(detailRow && detailPriceEl){
+            if(totals.ready && totals.detail > 0){
+              detailRow.hidden = false;
+              detailPriceEl.textContent = `+$${Math.round(totals.detail)}`;
+            } else {
+              detailRow.hidden = true;
+              detailPriceEl.textContent = '—';
+            }
+          }
+
+          const ready = totals.ready && hasAllRequired();
+          form.classList.toggle('quote-ready', ready);
+          if(seePriceBtn){ seePriceBtn.disabled = !ready; }
+
+          return totals;
+        }
+
+        pillControls.forEach(control => {
+          const targetName = control.dataset.targetInput;
+          if(!targetName) return;
+          const hiddenInput = form.querySelector(`input[name="${targetName}"]`);
+          if(!hiddenInput) return;
+
+          control.setAttribute('aria-pressed', 'false');
+
+          control.addEventListener('click', () => {
+            const group = control.closest('[role="radiogroup"]') || control.parentElement;
+            if(group){
+              Array.from(group.querySelectorAll('[data-target-input="' + targetName + '"]')).forEach(btn => {
+                const active = btn === control;
+                btn.classList.toggle('active', active);
+                btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+              });
+            }
+
+            hiddenInput.value = control.dataset.value || '';
+            hiddenInput.dataset.label = control.dataset.label || hiddenInput.value;
+            hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
+            updateServiceDetails(serviceInput ? serviceInput.value : '');
+            updateTotals();
+          });
         });
-        pill.setAttribute('tabindex', '0');
-        pill.setAttribute('role', 'button');
-        pill.setAttribute('aria-pressed', 'false');
+
+        requiredFields.forEach(field => {
+          const isSelect = field.tagName === 'SELECT';
+          const eventName = isSelect ? 'change' : 'input';
+          const handler = () => {
+            if(field.type === 'number'){
+              updateNumberMeta(field);
+            }
+            updateTotals();
+          };
+          field.addEventListener(eventName, handler);
+        });
+
+        numberFields.forEach(updateNumberMeta);
+        wireNumberSteppers();
+
+        if(basementField){
+          basementField.addEventListener('change', () => {
+            syncBasementExtras(serviceInput ? serviceInput.value : '');
+            updateTotals();
+          });
+        }
+
+        if(serviceInput){
+          serviceInput.addEventListener('change', () => {
+            updateServiceDetails(serviceInput.value);
+            updateTotals();
+          });
+        }
+
+        if(sqftInput){
+          sqftInput.addEventListener('change', updateTotals);
+        }
+
+        if(seePriceBtn){
+          seePriceBtn.addEventListener('click', () => {
+            if(seePriceBtn.disabled) return;
+            const totals = updateTotals();
+            if(!totals.ready) return;
+
+            const mode = form.dataset.quoteMode || 'redirect';
+            if(mode !== 'redirect') return;
+
+            const redirectTarget = form.dataset.redirect || 'book.html';
+            const url = new URL(redirectTarget, window.location.origin);
+            const params = url.searchParams;
+
+            const serviceValue = serviceInput ? serviceInput.value : '';
+            if(serviceValue){
+              params.set('service', serviceValue);
+              if(totals.serviceLabel){ params.set('serviceLabel', totals.serviceLabel); }
+            }
+
+            const sqftValue = sqftInput ? sqftInput.value : '';
+            if(sqftValue){
+              params.set('sqft', sqftValue);
+              if(totals.sqftLabel){ params.set('sqftLabel', totals.sqftLabel); }
+            }
+
+            params.set('basePrice', totals.base.toFixed(2));
+            params.set('detailPrice', totals.detail.toFixed(2));
+            params.set('total', totals.total.toFixed(2));
+
+            const firstName = form.querySelector('input[name="first-name"]');
+            if(firstName && firstName.value.trim()){
+              params.set('firstName', firstName.value.trim());
+            }
+
+            const email = form.querySelector('input[name="email"]');
+            if(email && email.value.trim()){
+              params.set('email', email.value.trim());
+            }
+
+            Object.entries(totals.selections || {}).forEach(([key, info]) => {
+              if(info.value){ params.set(key, info.value); }
+              if(info.label){ params.set(`${key}Label`, info.label); }
+            });
+
+            const anchor = form.dataset.redirectAnchor;
+            const finalUrl = anchor ? `${url.toString()}#${anchor}` : url.toString();
+            window.location.href = finalUrl;
+          });
+        }
+
+        updateServiceDetails(serviceInput ? serviceInput.value : '');
+        syncBasementExtras(serviceInput ? serviceInput.value : '');
+        updateTotals();
+      }
+    })();
+  </script>
+
+  <script>
+    (function(){
+      const navQuoteLink = document.querySelector('.nav-links .quote-btn');
+      const quoteSection = document.getElementById('quote');
+      if(!navQuoteLink || !quoteSection) return;
+
+      let spotlightTimer = null;
+
+      navQuoteLink.addEventListener('click', (event) => {
+        if(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        if(typeof event.button === 'number' && event.button !== 0) return;
+        event.preventDefault();
+        quoteSection.classList.remove('quote-spotlight');
+        void quoteSection.offsetWidth;
+        quoteSection.classList.add('quote-spotlight');
+        quoteSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+        const focusTarget = quoteSection.querySelector('input, button');
+        if(focusTarget){
+          try {
+            focusTarget.focus({ preventScroll: true });
+          } catch(_){
+            focusTarget.focus();
+          }
+        }
+
+        if(spotlightTimer){
+          window.clearTimeout(spotlightTimer);
+        }
+
+        spotlightTimer = window.setTimeout(() => {
+          quoteSection.classList.remove('quote-spotlight');
+          spotlightTimer = null;
+        }, 1600);
       });
-
-      requiredFields.forEach(field => {
-        const eventName = field.tagName === 'SELECT' ? 'change' : 'input';
-        field.addEventListener(eventName, toggleCustomize);
-      });
-
-      serviceSelect.addEventListener('change', () => {
-        updateAddonAvailability(serviceSelect.value);
-        calculateTotal();
-      });
-
-      sqftSelect.addEventListener('change', calculateTotal);
-
-      addonPills.forEach(pill => {
-        pill.setAttribute('aria-pressed', 'false');
-      });
-
-      toggleCustomize();
     })();
   </script>
 
@@ -707,57 +1033,5 @@
     })();
   </script>
 
-  <!-- Rotator logic (slide + bump + swipe) -->
-  <script>
-    (function(){
-      const box = document.getElementById('service-rotator');
-      if(!box) return;
-
-      const slides = Array.from(box.querySelectorAll('.rotator-line'));
-      const dots   = Array.from(box.querySelectorAll('.rotator-dots .dot'));
-      const underline = box.querySelector('.rotator-underline');
-      let idx = 0, timer = null, touchStartX = 0;
-
-      function show(n, bump=true){
-        // remove current
-        slides[idx].classList.remove('active');
-        dots[idx].classList.remove('active');
-
-        // set new
-        idx = (n + slides.length) % slides.length;
-        slides[idx].classList.add('active');
-        dots[idx].classList.add('active');
-
-        // restart underline anim
-        underline.style.animation = 'none';
-        requestAnimationFrame(()=>{ underline.style.animation = ''; });
-
-        // nudge the whole box so it feels like it moved
-        if(bump){ box.classList.remove('bump'); void box.offsetWidth; box.classList.add('bump'); }
-      }
-
-      function next(){ show(idx+1); }
-      function start(){ stop(); timer = setInterval(next, 4200); }
-      function stop(){ if(timer){ clearInterval(timer); timer=null; } }
-
-      // dots
-      dots.forEach((d,i)=> d.addEventListener('click', ()=>{ show(i); start(); }));
-
-      // swipe
-      box.addEventListener('touchstart', e=>{ touchStartX = e.touches[0].clientX; }, {passive:true});
-      box.addEventListener('touchend', e=>{
-        const dx = e.changedTouches[0].clientX - touchStartX;
-        if(Math.abs(dx) > 40){ show(idx + (dx<0 ? 1 : -1)); start(); }
-      }, {passive:true});
-
-      // hover pause (desktop)
-      box.addEventListener('mouseenter', stop);
-      box.addEventListener('mouseleave', start);
-
-      // init
-      slides.forEach((s,i)=> s.style.zIndex = String(10 - i));
-      show(0,false); start();
-    })();
-  </script>
 </body>
 </html>

--- a/nav-cart.js
+++ b/nav-cart.js
@@ -1,0 +1,257 @@
+(function(){
+  const CART_IMAGE_DATA_URI = window.CART_IMAGE_DATA_URI || 'data:image/png;base64,' +
+    'iVBORw0KGgoAAAANSUhEUgAAAlgAAAGQCAIAAAD9V4nPAAAE0UlEQVR42u3VMQ0AAAgEsdeCXXyiAxNsNKmCWy7VAwBvRQIAjBAA' +
+    'jBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAA' +
+    'jBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAA' +
+    'I1QBACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACME' +
+    'ACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACMEACME' +
+    'ACMEwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgB' +
+    'wAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgBwAgB' +
+    'wAgBwAgBwAgBMEIVADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBC' +
+    'ADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBCADBC' +
+    'ADBCADBCADBCADBCADBCAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQ' +
+    'AIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQ' +
+    'AIwQAIwQAIwQAIwQAIwQAIwQAIwQAIwQACOUAAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAj' +
+    'BAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAj' +
+    'BAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBAAjBMAIVQDACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHA' +
+    'CAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHA' +
+    'CAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAHACAEwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAw' +
+    'QgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgAwQgC4sEMVKv0E08xMAAAAAElFTkSuQmCC';
+
+  if(!window.CART_IMAGE_DATA_URI){
+    window.CART_IMAGE_DATA_URI = CART_IMAGE_DATA_URI;
+  }
+
+  function resolveCartImagePath(){
+    const candidates = [];
+    if(window.CART_IMAGE_PATH && typeof window.CART_IMAGE_PATH === 'string'){
+      candidates.push(window.CART_IMAGE_PATH);
+    }
+    if(document.body && document.body.dataset && typeof document.body.dataset.cartImage === 'string'){
+      candidates.push(document.body.dataset.cartImage);
+    }
+    for(const candidate of candidates){
+      if(candidate && typeof candidate === 'string' && candidate.trim()){
+        return candidate.trim();
+      }
+    }
+    return CART_IMAGE_DATA_URI;
+  }
+
+  const CART_IMAGE_PATH = resolveCartImagePath();
+
+  if(!window.CART_IMAGE_PATH){
+    window.CART_IMAGE_PATH = CART_IMAGE_PATH;
+  }
+
+  function applyCartImage(img){
+    if(!img){ return; }
+    const fallback = CART_IMAGE_DATA_URI;
+    const targetSrc = CART_IMAGE_PATH || fallback;
+    const shouldListenForErrors = fallback && targetSrc !== fallback;
+
+    function handleError(){
+      img.removeEventListener('error', handleError);
+      img.src = fallback;
+    }
+
+    if(shouldListenForErrors){
+      img.addEventListener('error', handleError);
+    }
+
+    img.src = targetSrc;
+  }
+
+  function clamp(value, min, max){
+    return Math.max(min, Math.min(max, value));
+  }
+
+  function init(){
+    const navCartButton = document.querySelector('[data-cart-toggle]');
+    const navPopover = document.getElementById('navCartPopover');
+    if(!navCartButton || !navPopover){
+      return;
+    }
+
+    const navCartCount = navCartButton.querySelector('[data-cart-count]');
+    const navCartLabel = navCartButton.querySelector('.nav-cart-label');
+    const navImage = navPopover.querySelector('[data-cart-popover-image]');
+    const serviceEl = navPopover.querySelector('[data-popover-service]');
+    const freqEl = navPopover.querySelector('[data-popover-frequency]');
+    const emptyEl = navPopover.querySelector('[data-popover-empty]');
+    const detailList = navPopover.querySelector('[data-popover-details]');
+    const totalsEl = navPopover.querySelector('[data-popover-totals]');
+    const totalValue = navPopover.querySelector('[data-popover-total]');
+    const depositValue = navPopover.querySelector('[data-popover-deposit]');
+    const balanceValue = navPopover.querySelector('[data-popover-balance]');
+    const paymentsEl = navPopover.querySelector('[data-popover-payments]');
+    const statusEl = navPopover.querySelector('[data-popover-status]');
+    const closeBtn = navPopover.querySelector('[data-cart-close]');
+    const googleBtn = navPopover.querySelector('[data-google-pay-button]');
+    const navPayPalStatus = navPopover.querySelector('#nav-paypal-status');
+
+    if(navImage && !navImage.getAttribute('src')){
+      applyCartImage(navImage);
+    }
+
+    let isOpen = false;
+    let currentState = null;
+
+    function setAriaExpanded(value){
+      navCartButton.setAttribute('aria-expanded', value ? 'true' : 'false');
+    }
+
+    function openPopover(){
+      if(isOpen) return;
+      isOpen = true;
+      navPopover.hidden = false;
+      navPopover.classList.add('nav-cart-popover-open');
+      navCartButton.classList.add('nav-cart-open');
+      setAriaExpanded(true);
+      document.dispatchEvent(new CustomEvent('nav-cart:opened', { detail: currentState }));
+    }
+
+    function closePopover(){
+      if(!isOpen) return;
+      isOpen = false;
+      navPopover.classList.remove('nav-cart-popover-open');
+      navCartButton.classList.remove('nav-cart-open');
+      setAriaExpanded(false);
+      window.setTimeout(() => {
+        if(!isOpen){
+          navPopover.hidden = true;
+        }
+      }, 180);
+    }
+
+    navCartButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      if(isOpen){
+        closePopover();
+      } else {
+        openPopover();
+      }
+    });
+
+    if(closeBtn){
+      closeBtn.addEventListener('click', closePopover);
+    }
+
+    document.addEventListener('click', (event) => {
+      if(!isOpen) return;
+      if(navPopover.contains(event.target) || navCartButton.contains(event.target)){
+        return;
+      }
+      closePopover();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if(event.key === 'Escape'){
+        closePopover();
+      }
+    });
+
+    function formatCurrency(amount){
+      if(!(amount > 0)) return '—';
+      return `$${Math.round(amount)}`;
+    }
+
+    function renderDetailList(state){
+      if(!detailList) return;
+      if(!state || !state.cartAdded){
+        detailList.hidden = true;
+        detailList.innerHTML = '';
+        return;
+      }
+
+      const rows = [];
+      if(state.basePrice){ rows.push(`<dt>Base</dt><dd>${formatCurrency(state.basePrice)}</dd>`); }
+      if(state.detailPrice){ rows.push(`<dt>Details</dt><dd>+${formatCurrency(state.detailPrice)}</dd>`); }
+      if(state.extrasTotal){ rows.push(`<dt>Add-ons</dt><dd>+${formatCurrency(state.extrasTotal)}</dd>`); }
+      if(state.discount){ rows.push(`<dt>Savings</dt><dd>-${formatCurrency(state.discount)}</dd>`); }
+      if(state.extrasLabel){ rows.push(`<dt>Included</dt><dd>${state.extrasLabel}</dd>`); }
+
+      detailList.hidden = rows.length === 0;
+      detailList.innerHTML = rows.length ? rows.join('') : '<dt>Package</dt><dd>Custom selections</dd>';
+    }
+
+    window.updateNavCartPopover = function(state){
+      currentState = state || null;
+      const hasItem = !!(state && state.cartAdded);
+
+      if(navCartCount){
+        navCartCount.hidden = !hasItem;
+        navCartCount.textContent = hasItem ? String(clamp(state && state.quantity ? state.quantity : 1, 1, 99)) : '';
+      }
+
+      navCartButton.classList.toggle('nav-cart-has-items', hasItem);
+
+      if(navCartLabel){
+        navCartLabel.classList.toggle('muted', !hasItem);
+      }
+
+      if(serviceEl){
+        serviceEl.textContent = hasItem
+          ? (state.serviceLabel || 'Custom Package')
+          : 'Your cart is empty';
+      }
+
+      if(freqEl){
+        freqEl.textContent = hasItem
+          ? (state.frequencyLabel || 'Choose a frequency to finalise your package.')
+          : 'Build a package to see pricing here.';
+      }
+
+      if(statusEl){
+        const message = state && state.status ? state.status : '';
+        statusEl.textContent = message;
+        statusEl.hidden = !message;
+      }
+
+      if(navPayPalStatus && !(state && state.cartAdded)){
+        navPayPalStatus.textContent = '';
+        navPayPalStatus.classList.remove('error');
+        navPayPalStatus.hidden = true;
+      }
+
+      if(emptyEl){
+        emptyEl.hidden = hasItem;
+      }
+
+      renderDetailList(state);
+
+      if(totalsEl){
+        totalsEl.hidden = !hasItem;
+        if(hasItem){
+          if(totalValue){ totalValue.textContent = formatCurrency(state.total); }
+          if(depositValue){ depositValue.textContent = formatCurrency(state.deposit); }
+          if(balanceValue){ balanceValue.textContent = formatCurrency(state.balance); }
+        }
+      }
+
+      if(paymentsEl){
+        const showPayments = hasItem && state.deposit && state.deposit > 0;
+        paymentsEl.hidden = !showPayments;
+        if(googleBtn){
+          googleBtn.disabled = !showPayments;
+        }
+      }
+
+      if(state && state.justAdded){
+        navCartButton.classList.add('nav-cart-pulse');
+        window.setTimeout(() => navCartButton.classList.remove('nav-cart-pulse'), 900);
+        if(isOpen){
+          document.dispatchEvent(new CustomEvent('nav-cart:opened', { detail: currentState }));
+        }
+      }
+    };
+
+    window.updateNavCartPopover();
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/services.html
+++ b/services.html
@@ -6,6 +6,7 @@
   <title>Our Services - DufferinDeepClean</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧼✨</text></svg>">
   <link rel="stylesheet" href="style.css" />
+  <script src="nav-cart.js" defer></script>
 </head>
 <body>
 
@@ -18,9 +19,47 @@
       <a href="index.html">Home</a>
       <a href="#services" class="services-btn-home">Our Services</a>
       <a href="about.html">About Us</a>
-      <a href="quote.html" class="quote-btn">Get Quote</a>
+      <a href="book.html#start" class="quote-btn">Book Online</a>
     </nav>
+    <div class="nav-actions">
+      <button class="nav-cart" type="button" data-cart-toggle aria-haspopup="dialog" aria-controls="navCartPopover" aria-expanded="false">
+        <span class="nav-cart-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path d="M4.5 4h-2a.5.5 0 0 1 0-1h2.8a1 1 0 0 1 .97.76L6.7 6H21a1 1 0 0 1 .96 1.27l-2 7A1 1 0 0 1 19 15H9.24l-.78 2.34A1 1 0 0 1 7.52 18H4.5a.5.5 0 0 1 0-1h2.55l3.2-9.6L9.8 6H4.78a1 1 0 0 1-.95-.68L4.5 4Zm4.28 3-2.4 7.2H19.1l1.71-6H8.78ZM9 19.75a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Zm9.5 0a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Z" fill="currentColor"/>
+          </svg>
+        </span>
+        <span class="nav-cart-label">Cart</span>
+        <span class="nav-cart-count" data-cart-count hidden>0</span>
+      </button>
+    </div>
   </header>
+  <aside class="nav-cart-popover" id="navCartPopover" role="dialog" aria-modal="false" aria-label="Cart summary" hidden>
+    <div class="nav-cart-popover-inner">
+      <button type="button" class="cart-popover-close" data-cart-close aria-label="Close cart">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <header class="cart-popover-header">
+        <img data-cart-popover-image alt="Cart package preview" loading="lazy" />
+        <div>
+          <p class="cart-popover-title" data-popover-service>Your cart is empty</p>
+          <p class="cart-popover-subtitle" data-popover-frequency>Build a package to see pricing here.</p>
+        </div>
+      </header>
+      <p class="cart-popover-status" data-popover-status hidden></p>
+      <p class="cart-popover-empty" data-popover-empty>Use “Book Online” to customise your cleaning package.</p>
+      <dl class="cart-popover-details" data-popover-details hidden></dl>
+      <div class="cart-popover-totals" data-popover-totals hidden>
+        <div><span>Visit total</span><span data-popover-total>—</span></div>
+        <div><span>Deposit (50%)</span><span data-popover-deposit>—</span></div>
+        <div><span>Balance</span><span data-popover-balance>—</span></div>
+      </div>
+      <div class="cart-popover-payments" data-popover-payments hidden>
+        <div id="nav-paypal-buttons" data-paypal-container="nav"></div>
+        <p class="cart-popover-paypal-status" id="nav-paypal-status" role="status" aria-live="polite"></p>
+        <button type="button" class="btn cart-popover-google" data-google-pay-button disabled>Google Pay (coming soon)</button>
+      </div>
+    </div>
+  </aside>
 
   <section class="services-page">
     <div class="services-header">

--- a/style.css
+++ b/style.css
@@ -107,10 +107,15 @@ h1, h2, h3 {
    NAVBAR
    ========================= */
 .navbar {
-  display: flex; justify-content: space-between; align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: clamp(1.2rem, 2.5vw, 3rem);
   padding: 1.5em 3em;
   background: linear-gradient(to right, #000, #111);
-  position: sticky; top: 0; z-index: 1000;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 
 /* Logo with soap + sparkle */
@@ -130,7 +135,15 @@ h1, h2, h3 {
 
 /* Nav links */
 .nav-links { display: flex; align-items: center; gap: 1.75rem; }
-.nav-links a { color: #eee; font-size: 1rem; transition: color .3s ease; }
+.nav-links a {
+  color: #e9f7ff;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition: color 0.3s ease;
+}
 .nav-links a:hover { color: #00d4ff; }
 
 /* =========================
@@ -177,7 +190,12 @@ h1, h2, h3 {
 }
 
 /* Headline */
-.headline { font-size: 3rem; font-weight: 800; line-height: 1.2; }
+.headline {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1.2;
+  margin-top: clamp(1.75rem, 4vw, 3.5rem);
+}
 .headline span { display: inline-block; animation: fadeIn 1s ease forwards; opacity: 0; }
 .headline span:nth-child(1){animation-delay:.3s}
 .headline span:nth-child(2){animation-delay:.6s}
@@ -209,9 +227,9 @@ h1, h2, h3 {
    QUOTE PANEL
    ========================= */
 .hero-quote {
-  margin-top: clamp(1.8rem, 4vw, 2.8rem);
+  margin-top: clamp(1.4rem, 3vw, 2.1rem);
   width: 100%;
-  max-width: 640px;
+  max-width: 580px;
   display: flex;
   align-self: flex-start;
 }
@@ -219,17 +237,18 @@ h1, h2, h3 {
 .quote-card {
   width: 100%;
   flex: 1;
-  padding: clamp(1.8rem, 3vw, 2.45rem);
-  border-radius: 32px;
-  border: 1.5px solid rgba(0, 212, 255, 0.45);
-  background: linear-gradient(135deg, rgba(8, 19, 30, 0.75), rgba(12, 24, 40, 0.55));
+  padding: clamp(1.1rem, 2.5vw, 1.75rem);
+  border-radius: 22px;
+  border: 1.8px solid rgba(0, 212, 255, 0.55);
+  background: linear-gradient(135deg, rgba(8, 19, 30, 0.82), rgba(10, 26, 38, 0.58));
   box-shadow:
-    0 35px 120px rgba(0, 0, 0, 0.6),
-    0 0 30px rgba(0, 212, 255, 0.25),
-    inset 0 0 35px rgba(0, 212, 255, 0.08);
-  backdrop-filter: blur(16px);
+    0 26px 90px rgba(0, 0, 0, 0.58),
+    0 0 22px rgba(0, 212, 255, 0.22),
+    inset 0 0 28px rgba(0, 212, 255, 0.06);
+  backdrop-filter: blur(14px);
   position: relative;
   overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .quote-card::before {
@@ -237,79 +256,421 @@ h1, h2, h3 {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1.5px solid rgba(0, 212, 255, 0.35);
+  border: 2.2px solid rgba(0, 212, 255, 0.28);
   pointer-events: none;
   box-shadow: 0 0 45px rgba(0, 212, 255, 0.2);
   opacity: 0.6;
 }
 
+.hero-quote.quote-spotlight .quote-card {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 2px rgba(0, 212, 255, 0.65),
+    0 32px 70px rgba(0, 0, 0, 0.6),
+    inset 0 0 32px rgba(0, 212, 255, 0.12);
+}
+
+.hero-quote.quote-spotlight .quote-card::before {
+  animation: quotePulse 1.2s ease-in-out 2;
+}
+
+@keyframes quotePulse {
+  0%, 100% {
+    opacity: 0.6;
+    box-shadow: 0 0 45px rgba(0, 212, 255, 0.2);
+  }
+  50% {
+    opacity: 0.95;
+    box-shadow: 0 0 80px rgba(0, 212, 255, 0.35);
+  }
+}
+
 .quote-card-header {
-  margin-bottom: 1.75rem;
+  margin-bottom: 1.1rem;
 }
 
 .quote-card-header h2 {
-  font-size: clamp(1.9rem, 3vw, 2.55rem);
-  letter-spacing: 0.12em;
+  font-size: clamp(1.32rem, 2.6vw, 1.85rem);
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: #e6f8ff;
-  margin-bottom: 0.75rem;
-  text-shadow: 0 0 22px rgba(0, 212, 255, 0.45);
+  margin-bottom: 0.45rem;
+  text-shadow: 0 0 18px rgba(0, 212, 255, 0.35);
 }
 
 .quote-card-header p {
-  color: rgba(212, 235, 255, 0.78);
-  font-size: 0.98rem;
-  max-width: 32ch;
+  color: rgba(212, 235, 255, 0.75);
+  font-size: 0.86rem;
+  max-width: 30ch;
 }
 
 .quote-form {
   display: flex;
   flex-direction: column;
-  gap: 1.65rem;
+  gap: 1.15rem;
 }
 
 .quote-grid {
   display: grid;
-  gap: 1.2rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.4rem;
+}
+
+.field-inline {
+  gap: 0.3rem;
 }
 
 .field-label {
-  font-size: 0.95rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(173, 214, 255, 0.85);
+  letter-spacing: 0.16em;
+  color: rgba(173, 214, 255, 0.82);
+}
+
+.select-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: rgba(5, 14, 24, 0.75);
+  border: 1px solid rgba(0, 212, 255, 0.28);
+  border-radius: 14px;
+  padding: 0.1rem 0.4rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.select-wrap::after {
+  content: "▾";
+  font-size: 0.65rem;
+  color: rgba(173, 214, 255, 0.8);
+  pointer-events: none;
+  margin-left: 0.3rem;
+}
+
+.select-wrap select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0.45rem 1.4rem 0.45rem 0.35rem;
+  font-size: 0.9rem;
+  color: #ecf5ff;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.select-wrap select option {
+  color: #0b161e;
+  background: #ecf5ff;
+}
+
+.select-wrap select:focus {
+  outline: none;
+}
+
+.select-wrap:focus-within {
+  border-color: rgba(0, 212, 255, 0.55);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.select-wrap.compact {
+  padding: 0.05rem 0.35rem;
+}
+
+.select-wrap.compact select {
+  font-size: 0.82rem;
+  padding: 0.35rem 1.2rem 0.35rem 0.3rem;
 }
 
 .field input,
 .field select {
-  padding: 0.85rem 1rem;
-  border-radius: 16px;
-  border: 1.5px solid rgba(0, 212, 255, 0.25);
-  background: rgba(8, 19, 32, 0.75);
+  padding: 0.65rem 0.85rem;
+  border-radius: 14px;
+  border: 1.2px solid rgba(0, 212, 255, 0.22);
+  background: rgba(8, 19, 32, 0.72);
   color: #f2fbff;
-  font-size: 1rem;
-  box-shadow: inset 0 0 18px rgba(0, 212, 255, 0.06);
+  font-size: 0.92rem;
+  box-shadow: inset 0 0 14px rgba(0, 212, 255, 0.05);
   transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
 .field input:focus,
 .field select:focus {
   outline: none;
-  border-color: rgba(0, 212, 255, 0.65);
-  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  border-color: rgba(0, 212, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
   transform: translateY(-1px);
 }
 
+.mini-pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.mini-pill {
+  appearance: none;
+  border: 1px solid rgba(0, 212, 255, 0.25);
+  background: rgba(6, 16, 26, 0.75);
+  color: #e9faff;
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  min-width: 58px;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.mini-pill:hover,
+.mini-pill:focus-visible {
+  border-color: rgba(0, 212, 255, 0.5);
+  color: #fff;
+  outline: none;
+}
+
+.mini-pill.active {
+  background: linear-gradient(135deg, rgba(0, 212, 255, 0.35), rgba(0, 128, 255, 0.35));
+  border-color: rgba(0, 212, 255, 0.75);
+  color: #0b161e;
+  box-shadow: 0 8px 18px rgba(0, 212, 255, 0.25);
+}
+
+
+.service-details {
+  margin-top: 0.15rem;
+  display: grid;
+  gap: 0.45rem;
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 0.3s ease, transform 0.3s ease, max-height 0.35s ease;
+}
+
+.service-details.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  max-height: 320px;
+}
+
+.service-detail-group {
+  display: none;
+  gap: 0.5rem;
+}
+
+.service-detail-group.active {
+  display: grid;
+  gap: 0.5rem;
+  animation: detailFade 0.3s ease forwards;
+}
+
+.service-detail-group.detail-inline {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  align-items: end;
+  position: relative;
+}
+
+.service-detail-group.detail-inline[data-service-detail="home"] {
+  max-height: 235px;
+  overflow-y: auto;
+  padding-right: 0.4rem;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 212, 255, 0.35) transparent;
+}
+
+.service-detail-group.detail-inline[data-service-detail="home"]::-webkit-scrollbar {
+  width: 6px;
+}
+
+.service-detail-group.detail-inline[data-service-detail="home"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.service-detail-group.detail-inline[data-service-detail="home"]::-webkit-scrollbar-thumb {
+  background: rgba(0, 212, 255, 0.35);
+  border-radius: 12px;
+}
+
+/* Ensure navigation typography matches the quote heading across pages */
+.nav-links a {
+  font-family: 'Inter', sans-serif !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.16em !important;
+  font-weight: 600 !important;
+  font-size: 0.95rem !important;
+  color: #e9f7ff !important;
+}
+
+@keyframes detailFade {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.service-detail-title {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(173, 214, 255, 0.6);
+}
+
+.detail-card-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.detail-inline-field {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.45rem 0.55rem 0.4rem;
+  border-radius: 14px;
+  border: 1px solid rgba(0, 212, 255, 0.2);
+  background: rgba(4, 16, 27, 0.75);
+  box-shadow: inset 0 0 10px rgba(0, 212, 255, 0.05);
+  min-height: 100%;
+}
+
+.detail-inline-basement {
+  justify-self: stretch;
+}
+
+.detail-basement-extra {
+  grid-column: 1 / -1;
+  display: none;
+  gap: 0.45rem;
+  padding-top: 0.1rem;
+  animation: detailFade 0.3s ease forwards;
+}
+
+.detail-basement-extra.visible {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.detail-inline-field .detail-card-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(173, 214, 255, 0.75);
+}
+
+.number-wrap {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 212, 255, 0.26);
+  background: rgba(2, 14, 24, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(0, 212, 255, 0.05);
+}
+
+.number-wrap input[type="number"] {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: #e6f4ff;
+  font-weight: 600;
+  font-size: 1rem;
+  text-align: center;
+  padding: 0.35rem 0.25rem;
+}
+
+.number-wrap input::-webkit-outer-spin-button,
+.number-wrap input::-webkit-inner-spin-button,
+.addon-qty::-webkit-outer-spin-button,
+.addon-qty::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.number-wrap input[type="number"],
+.addon-qty {
+  -moz-appearance: textfield;
+}
+
+.number-wrap input[type="number"]:focus {
+  outline: none;
+  color: #ffffff;
+}
+
+.number-wrap:focus-within {
+  border-color: rgba(0, 212, 255, 0.55);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.16);
+}
+
+.detail-inline-pets .mini-pill-group {
+  justify-content: space-between;
+}
+
+.detail-card {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.65rem;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 212, 255, 0.18);
+  background: radial-gradient(circle at top, rgba(10, 26, 38, 0.75), rgba(6, 14, 26, 0.82));
+  box-shadow: inset 0 0 12px rgba(0, 212, 255, 0.08);
+  position: relative;
+  overflow: hidden;
+  align-content: start;
+}
+
+.detail-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(0, 212, 255, 0.08), rgba(0, 212, 255, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.detail-card:focus-within::after,
+.detail-card:hover::after {
+  opacity: 1;
+}
+
+.detail-card-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(173, 214, 255, 0.72);
+}
+
+.mini-pill-group.tight {
+  gap: 0.35rem;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.mini-pill-group.tight .mini-pill {
+  min-width: 48px;
+  padding: 0.35rem 0.7rem;
+}
+
 .quote-summary {
-  padding: 1.2rem 1.4rem;
-  border-radius: 24px;
+  padding: 0.95rem 1.05rem;
+  border-radius: 18px;
   background: rgba(10, 22, 34, 0.65);
   border: 1px solid rgba(0, 212, 255, 0.22);
   box-shadow: inset 0 0 22px rgba(0, 212, 255, 0.08);
@@ -317,6 +678,43 @@ h1, h2, h3 {
   gap: 0.85rem;
   opacity: 0.55;
   transition: opacity 0.35s ease;
+}
+
+.quote-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.quote-see-price {
+  appearance: none;
+  border-radius: 14px;
+  border: 1.5px solid rgba(0, 212, 255, 0.35);
+  background: linear-gradient(180deg, rgba(0, 212, 255, 0.25), rgba(0, 212, 255, 0.1));
+  color: #f2fbff;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.65rem 1.4rem;
+  font-size: 0.86rem;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, transform 0.25s ease, color 0.25s ease;
+}
+
+.quote-see-price:not(:disabled):hover,
+.quote-see-price:not(:disabled):focus-visible {
+  border-color: rgba(0, 212, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.2);
+  background: linear-gradient(180deg, rgba(0, 212, 255, 0.45), rgba(0, 212, 255, 0.2));
+  transform: translateY(-1px);
+}
+
+.quote-see-price:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  background: rgba(8, 19, 32, 0.45);
+  border-color: rgba(0, 212, 255, 0.18);
+  color: rgba(214, 238, 255, 0.6);
 }
 
 .quote-form.quote-ready .quote-summary {
@@ -327,20 +725,144 @@ h1, h2, h3 {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   color: rgba(214, 238, 255, 0.85);
 }
 
 .quote-summary-line strong {
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   letter-spacing: 0.05em;
   color: #f7fdff;
   text-shadow: 0 0 12px rgba(0, 212, 255, 0.35);
 }
 
 .quote-summary-line.total {
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
+}
+
+@media (min-width: 1024px) {
+  .split-screen {
+    gap: clamp(1rem, 2vw, 1.6rem);
+  }
+
+  .split-screen .text-side {
+    padding: clamp(2.2rem, 4vw, 3.1rem);
+    gap: 1.1rem;
+  }
+
+  .split-screen .hero-quote {
+    max-width: 440px;
+  }
+
+  .split-screen .hero-quote .quote-card {
+    padding: 0.95rem 1.05rem;
+    border-radius: 18px;
+    box-shadow:
+      0 16px 48px rgba(0, 0, 0, 0.45),
+      0 0 14px rgba(0, 212, 255, 0.18),
+      inset 0 0 16px rgba(0, 212, 255, 0.05);
+  }
+
+  .split-screen .hero-quote .quote-card-header {
+    margin-bottom: 0.85rem;
+  }
+
+  .split-screen .hero-quote .quote-card-header h2 {
+    font-size: 1.42rem;
+    letter-spacing: 0.14em;
+  }
+
+  .split-screen .hero-quote .quote-card-header p {
+    font-size: 0.75rem;
+    max-width: 26ch;
+  }
+
+  .split-screen .hero-quote .quote-form {
+    gap: 0.9rem;
+  }
+
+  .split-screen .hero-quote .quote-grid {
+    gap: 0.6rem;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  }
+
+  .split-screen .hero-quote .field {
+    gap: 0.3rem;
+  }
+
+  .split-screen .hero-quote .field-label {
+    font-size: 0.68rem;
+    letter-spacing: 0.16em;
+  }
+
+  .split-screen .hero-quote .field input,
+  .split-screen .hero-quote .field select {
+    padding: 0.5rem 0.65rem;
+    border-radius: 10px;
+    font-size: 0.8rem;
+  }
+
+  .split-screen .hero-quote .mini-pill-group {
+    gap: 0.35rem;
+  }
+
+  .split-screen .hero-quote .mini-pill {
+    padding: 0.32rem 0.55rem;
+    min-height: 28px;
+    min-width: 52px;
+    font-size: 0.68rem;
+  }
+
+  .split-screen .hero-quote .service-details {
+    gap: 0.5rem;
+  }
+
+  .split-screen .hero-quote .service-details.visible {
+    padding: 0;
+  }
+
+  .split-screen .hero-quote .service-detail-group {
+    gap: 0.45rem;
+  }
+
+  .split-screen .hero-quote .detail-basement-extra.visible {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  }
+
+  .split-screen .hero-quote .detail-card-grid {
+    gap: 0.45rem;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  }
+
+  .split-screen .hero-quote .detail-card {
+    padding: 0.55rem;
+  }
+
+  .split-screen .hero-quote .quote-summary {
+    padding: 0.65rem 0.75rem;
+    border-radius: 14px;
+    gap: 0.55rem;
+  }
+
+  .split-screen .hero-quote .quote-summary-line {
+    font-size: 0.82rem;
+  }
+
+  .split-screen .hero-quote .quote-summary-line strong {
+    font-size: 0.92rem;
+  }
+
+  .split-screen .hero-quote .quote-actions {
+    margin-top: 0.65rem;
+  }
+
+  .split-screen .hero-quote .quote-see-price {
+    padding: 0.55rem 1.15rem;
+    border-radius: 12px;
+    font-size: 0.76rem;
+    letter-spacing: 0.1em;
+  }
 }
 
 .quote-customize {
@@ -376,7 +898,7 @@ h1, h2, h3 {
 
 .addon-groups {
   display: grid;
-  gap: 1.8rem;
+  gap: 1.4rem;
 }
 
 .addon-group-title {
@@ -391,63 +913,142 @@ h1, h2, h3 {
   display: none;
 }
 
+
 .addon-group.active {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.7rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .addon-pill {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 999px;
-  background: rgba(16, 32, 48, 0.6);
-  border: 1.5px solid rgba(0, 212, 255, 0.18);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  gap: 0.65rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 18px;
+  background: rgba(10, 24, 38, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.36);
   cursor: pointer;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+  overflow: hidden;
 }
 
-.addon-pill:hover {
-  transform: scale(1.06);
-  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.45);
+.addon-pill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.addon-pill:hover,
+.addon-pill:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.42);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.addon-pill:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.addon-pill:hover::after,
+.addon-pill:focus-visible::after,
+.addon-pill.active::after {
+  opacity: 0.65;
 }
 
 .addon-pill.active {
-  border-color: rgba(0, 212, 255, 0.65);
-  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.25), 0 22px 40px rgba(0, 0, 0, 0.55);
+  border-color: rgba(0, 212, 255, 0.55);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.5), 0 0 0 2px rgba(0, 212, 255, 0.35);
 }
 
 .addon-icon {
-  font-size: 1.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  color: #f6fbff;
   flex-shrink: 0;
+}
+
+.addon-icon svg {
+  width: 28px;
+  height: 28px;
+  transition: transform 0.35s ease;
+}
+
+.addon-pill:hover .addon-icon svg,
+.addon-pill:focus-visible .addon-icon svg,
+.addon-pill.active .addon-icon svg {
+  transform: translateY(-2px) scale(1.08);
 }
 
 .addon-name {
   flex: 1;
-  font-size: 1rem;
-  color: rgba(226, 245, 255, 0.9);
+  font-size: 0.78rem;
+  line-height: 1.2;
+  color: rgba(226, 245, 255, 0.92);
+  font-weight: 600;
+}
+
+.addon-stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.18rem 0.3rem;
+  border-radius: 12px;
+  background: rgba(3, 18, 30, 0.65);
+  border: 1px solid rgba(0, 212, 255, 0.22);
+  transition: border-color 0.25s ease, background 0.25s ease;
+}
+
+.addon-stepper .stepper-button {
+  width: 26px;
+  height: 26px;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .addon-group.active {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .addon-group.active {
+    grid-template-columns: 1fr;
+  }
+}
+
+.addon-stepper:focus-within,
+.addon-pill.active .addon-stepper {
+  border-color: rgba(0, 212, 255, 0.45);
+  background: rgba(6, 26, 44, 0.82);
 }
 
 .addon-qty {
-  width: 3.5rem;
-  padding: 0.4rem 0.5rem;
-  border-radius: 14px;
-  border: 1.5px solid rgba(0, 212, 255, 0.35);
-  background: rgba(6, 20, 32, 0.75);
+  width: 2.3rem;
+  background: transparent;
+  border: none;
   color: #f2fbff;
-  font-size: 1rem;
-  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  text-align: center;
+  font-weight: 700;
+  font-size: 0.82rem;
 }
 
 .addon-qty:focus {
   outline: none;
-  border-color: rgba(0, 212, 255, 0.7);
-  box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.18);
 }
+
 
 .addon-pill:not(.active) .addon-qty {
   opacity: 0.4;
@@ -489,20 +1090,22 @@ h1, h2, h3 {
   }
 
   .addon-group.active {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(68px, 1fr));
   }
 
   .addon-pill {
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    width: 68px;
+    min-height: 68px;
+    padding: 0.35rem;
+    gap: 0.28rem;
   }
 
   .addon-name {
-    flex-basis: 100%;
+    font-size: 0.62rem;
   }
 
   .addon-qty {
-    width: 100%;
+    font-size: 0.7rem;
   }
 }
 .services-btn-home:hover { background:#00d4ff; color:#000; transform: translateY(-2px); box-shadow: 0 8px 20px rgba(0,212,255,.3); }
@@ -1013,99 +1616,6 @@ body {
     background-position: 300px 300px; /* same as background-size for seamless diagonal */
   }
 }
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/style.css b/style.css
-index 0b20d0b0893d1dc4b3df65017bd88c8ab164a1ed..57860dcd49adb346da926e55d50687586c7d04b4 100644
---- a/style.css
-+++ b/style.css
-@@ -118,53 +118,82 @@ h1, h2, h3 {
-   animation: fadeInUp 0.4s ease forwards; transform: translateY(-10px); opacity: 0; animation-delay: 0.2s; position: relative; }
- .logo .soap { font-size: 2.5rem; margin-right: .5rem; transform: scale(1.1); opacity: 1;
-   animation: popIn 1.2s ease; animation-delay: .2s; animation-fill-mode: backwards; position: relative; }
- .logo .soap::after { content: '✨'; position: absolute; font-size: .9rem; top: -10px; right: -8px;
-   animation: sparkle 1.2s ease-in-out infinite; color: #fff; opacity: .8; }
- .logo-text { font-size: 1.8rem; text-transform: lowercase; letter-spacing: 1px;
-   animation: fadeInUp 0.1s ease forwards; opacity: 0; animation-delay: .3s; }
- 
- @keyframes popIn { 0%{transform:scale(.5) rotate(-30deg);opacity:0} 60%{transform:scale(1.3) rotate(10deg);opacity:1} 100%{transform:scale(1.1)} }
- @keyframes fadeInUp { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
- @keyframes sparkle { 0%,100%{opacity:.8;transform:scale(1) rotate(0)} 50%{opacity:1;transform:scale(1.2) rotate(20deg)} }
- 
- /* Nav links */
- .nav-links a { margin-left: 2rem; color: #eee; font-size: 1rem; transition: color .3s ease; }
- .nav-links a:hover { color: #00d4ff; }
- 
- /* =========================
-    HERO SPLIT
-    ========================= */
- .split-screen { display: flex; height: 90vh; width: 100%; position: relative; z-index: 2; }
- .text-side {
-   flex: 1; display: flex; flex-direction: column; justify-content: center; padding: 4em;
-   /* (grid removed above) */
- }
- .image-side { flex: 1; overflow: hidden; display: flex; justify-content: flex-start; align-items: center; position: relative; z-index: 1; }
-+.image-side::before { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 180px;
-+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.75) 70%, rgba(0, 0, 0, 0.95) 100%);
-+  pointer-events: none; z-index: 2; }
- .image-side::after { content: ""; position: absolute; left: 0; top: 0; height: 100%; width: 120px;
--  background: linear-gradient(to right, black, transparent); z-index: 2; pointer-events: none; }
--.image-side img { width: 100%; height: 100%; object-fit: cover; position: relative; z-index: 0; transform: translateX(-40px); }
-+  background: linear-gradient(to right, black, transparent); z-index: 3; pointer-events: none; }
-+.image-side img {
-+  width: 100%;
-+  height: 100%;
-+  object-fit: cover;
-+  position: relative;
-+  z-index: 0;
-+  transform: translateX(-40px);
-+  /* soften the bottom edge so the hero image fades into the background */
-+  -webkit-mask-image: linear-gradient(
-+    to bottom,
-+    rgba(0, 0, 0, 1) 55%,
-+    rgba(0, 0, 0, 0.85) 70%,
-+    rgba(0, 0, 0, 0.55) 82%,
-+    rgba(0, 0, 0, 0.2) 92%,
-+    rgba(0, 0, 0, 0) 100%
-+  );
-+  mask-image: linear-gradient(
-+    to bottom,
-+    rgba(0, 0, 0, 1) 55%,
-+    rgba(0, 0, 0, 0.85) 70%,
-+    rgba(0, 0, 0, 0.55) 82%,
-+    rgba(0, 0, 0, 0.2) 92%,
-+    rgba(0, 0, 0, 0) 100%
-+  );
-+  -webkit-mask-size: 100% 100%;
-+  mask-size: 100% 100%;
-+}
- 
- /* Headline */
- .headline { font-size: 3rem; font-weight: 800; line-height: 1.2; }
- .headline span { display: inline-block; animation: fadeIn 1s ease forwards; opacity: 0; }
- .headline span:nth-child(1){animation-delay:.3s}
- .headline span:nth-child(2){animation-delay:.6s}
- .headline span:nth-child(3){animation-delay:.9s}
- .headline span:nth-child(4){animation-delay:1.2s}
- .headline-image { height: 1em; width: auto; display: inline-block; margin-left: .5rem; vertical-align: baseline;
-   animation: fadeIn 1s ease forwards; opacity: 0; animation-delay: 1.5s; }
- @keyframes fadeIn { to { opacity: 1; transform: translateY(0); } }
- 
- /* Subtext & CTAs */
- .subtext { font-size: 1.1rem; margin-top: 2rem; color: #ccc; max-width: 500px; }
- .quote-btn-home {
-   margin-top: 3rem; padding: .8em 2em; background: #00d4ff; color: #000 !important; font-weight: bold;
-   border: none; border-radius: 14px; font-size: 1.5rem; cursor: pointer; align-self: flex-start;
-   animation: fadeInUp 1.5s ease forwards; opacity: 0; transform: translateY(20px);
-   transition: background .3s ease, transform .3s ease;
- }
- .quote-btn-home:hover { background: white; color: black !important; }
- .quote-btn-home:visited, .quote-btn-home:link { color: black !important; }
- 
- .services-btn-home {
-   margin-top: 1.5rem; padding: .8em 2em; background: transparent; color: #00d4ff; font-weight: bold;
- 
-EOF
-)
 /* Google Font */
 @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap');
 
@@ -1221,6 +1731,402 @@ h1, h2, h3 {
 .nav-links { display: flex; align-items: center; gap: 1.75rem; }
 .nav-links a { color: #eee; font-size: 1rem; transition: color .3s ease; }
 .nav-links a:hover { color: #00d4ff; }
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.65rem, 1.4vw, 1.25rem);
+}
+
+.nav-cart {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.nav-cart {
+  gap: 0.55rem;
+  padding: 0.55em 1.1em;
+  border: 1px solid rgba(0, 212, 255, 0.35);
+  background: rgba(3, 18, 30, 0.55);
+  color: #e9f7ff;
+  backdrop-filter: blur(6px);
+  position: relative;
+}
+
+.nav-cart:hover,
+.nav-cart:focus-visible {
+  background: rgba(0, 212, 255, 0.18);
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 212, 255, 0.18);
+}
+
+.nav-cart.nav-cart-has-items {
+  border-color: rgba(255, 128, 210, 0.8);
+  background: linear-gradient(135deg, rgba(255, 165, 228, 0.2), rgba(255, 79, 195, 0.95));
+  color: #fff;
+  box-shadow: 0 18px 40px rgba(255, 79, 195, 0.32);
+  animation: navCartBreath 2.8s ease-in-out infinite;
+}
+
+.nav-cart.nav-cart-has-items.nav-cart-pulse {
+  animation: navCartPulse 0.9s ease, navCartBreath 2.8s ease-in-out infinite;
+}
+
+.nav-cart.nav-cart-has-items:hover,
+.nav-cart.nav-cart-has-items:focus-visible {
+  background: linear-gradient(135deg, rgba(255, 195, 240, 0.35), rgba(255, 79, 195, 1));
+  box-shadow: 0 20px 48px rgba(255, 79, 195, 0.4);
+}
+
+.nav-cart.nav-cart-has-items .nav-cart-count {
+  background: linear-gradient(135deg, #ffe7f7, #ff9ee4);
+  color: #3f0f30;
+}
+
+.nav-cart-icon svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+
+.nav-cart-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.55rem;
+  height: 1.55rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #ff90dc, #ff4fc3);
+  color: #051320;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  box-shadow: 0 8px 18px rgba(255, 79, 195, 0.35);
+}
+
+.nav-cart:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.nav-cart-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+}
+
+.nav-cart-label.muted {
+  opacity: 0.6;
+}
+
+.nav-cart.nav-cart-has-items::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(255, 79, 195, 0.35) 0%, rgba(255, 79, 195, 0) 65%);
+  opacity: 0.6;
+  filter: blur(4px);
+  z-index: -1;
+}
+
+.nav-cart.nav-cart-has-items:hover::before,
+.nav-cart.nav-cart-has-items:focus-visible::before {
+  opacity: 0.85;
+}
+
+.nav-cart-pulse {
+  animation: navCartPulse 0.9s ease;
+}
+
+@keyframes navCartPulse {
+  0% { transform: scale(1); }
+  30% { transform: scale(1.08); }
+  60% { transform: scale(0.96); }
+  100% { transform: scale(1); }
+}
+
+@keyframes navCartBreath {
+  0%, 100% {
+    box-shadow: 0 18px 40px rgba(255, 79, 195, 0.32), 0 0 0 0 rgba(255, 79, 195, 0.36);
+  }
+  50% {
+    box-shadow: 0 20px 50px rgba(255, 79, 195, 0.45), 0 0 0 16px rgba(255, 79, 195, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-cart.nav-cart-has-items {
+    animation: none;
+  }
+}
+
+.nav-cart-popover {
+  position: fixed;
+  top: clamp(72px, 6vw, 96px);
+  right: clamp(16px, 4vw, 42px);
+  width: min(360px, calc(100vw - 28px));
+  z-index: 1200;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-14px) scale(0.96);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.nav-cart-popover:not([hidden]) {
+  display: block;
+}
+
+.nav-cart-popover.nav-cart-popover-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.nav-cart-popover-inner {
+  background: rgba(4, 12, 20, 0.92);
+  border: 1px solid rgba(0, 212, 255, 0.28);
+  border-radius: 20px;
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.55);
+  padding: 1.1rem;
+  backdrop-filter: blur(8px);
+  color: #f1fbff;
+  position: relative;
+  overflow: hidden;
+}
+
+.nav-cart-popover-inner::before {
+  content: "";
+  position: absolute;
+  inset: -40% -50% auto auto;
+  height: 180px;
+  width: 180px;
+  background: radial-gradient(circle, rgba(0, 212, 255, 0.25), transparent 65%);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.cart-popover-close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  appearance: none;
+  border: none;
+  background: rgba(2, 10, 18, 0.65);
+  color: rgba(255, 255, 255, 0.75);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.cart-popover-close:hover,
+.cart-popover-close:focus-visible {
+  background: rgba(0, 212, 255, 0.24);
+  color: #051320;
+  outline: none;
+}
+
+.cart-popover-header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin-bottom: 0.85rem;
+}
+
+.cart-popover-header img {
+  width: 68px;
+  height: 68px;
+  border-radius: 16px;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.cart-popover-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.cart-popover-subtitle {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(221, 241, 255, 0.78);
+}
+
+.cart-popover-status {
+  margin: 0 0 0.75rem;
+  font-size: 0.82rem;
+  color: rgba(255, 212, 112, 0.95);
+}
+
+.cart-popover-empty {
+  margin: 0 0 0.8rem;
+  font-size: 0.85rem;
+  color: rgba(221, 241, 255, 0.68);
+}
+
+.cart-popover-details {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0 0 0.8rem;
+  font-size: 0.82rem;
+}
+
+.cart-popover-details dt {
+  font-weight: 600;
+  color: rgba(221, 241, 255, 0.75);
+}
+
+.cart-popover-details dd {
+  margin: 0;
+  color: rgba(241, 250, 255, 0.9);
+}
+
+.cart-popover-totals {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+  font-size: 0.88rem;
+}
+
+.cart-popover-totals div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.cart-popover-payments {
+  display: grid;
+  gap: 0.6rem;
+  margin-bottom: 0.85rem;
+}
+
+[data-paypal-container] {
+  width: 100%;
+}
+
+.cart-popover-paypal-status {
+  font-size: 0.78rem;
+  margin: 0;
+  color: rgba(221, 241, 255, 0.85);
+}
+
+.cart-popover-paypal-status.error {
+  color: #ff86ac;
+}
+
+.cart-popover-google {
+  background: linear-gradient(135deg, #4aa9ff, #006bff);
+  color: #ffffff;
+  letter-spacing: 0.14em;
+  box-shadow: 0 12px 30px rgba(0, 107, 255, 0.28);
+}
+
+.cart-popover-google[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: linear-gradient(135deg, rgba(74, 169, 255, 0.35), rgba(0, 107, 255, 0.25));
+  box-shadow: none;
+}
+
+@media (max-width: 620px) {
+  .nav-cart-popover {
+    right: 50%;
+    left: 50%;
+    transform: translate(-50%, -14px) scale(0.96);
+    width: min(360px, calc(100vw - 20px));
+  }
+
+  .nav-cart-popover.nav-cart-popover-open {
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+.cart-flight {
+  position: fixed;
+  z-index: 1500;
+  pointer-events: none;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+}
+
+.cart-flight img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+@media (max-width: 1024px) {
+  .navbar {
+    padding: 1.25em 2.25em;
+    gap: clamp(1rem, 2vw, 2.2rem);
+  }
+
+  .nav-links {
+    gap: 1.3rem;
+  }
+
+}
+
+@media (max-width: 900px) {
+  .navbar {
+    padding: 1.1em 1.75em;
+  }
+
+  .nav-cart {
+    gap: 0.4rem;
+    padding: 0.45em 0.8em;
+  }
+
+  .nav-cart-label {
+    display: none;
+  }
+
+}
+
+@media (max-width: 640px) {
+  .navbar {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem 1.5rem;
+  }
+
+  .logo {
+    order: 1;
+  }
+
+  .nav-links {
+    order: 2;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.9rem;
+  }
+
+  .nav-actions {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+  }
+}
 
 /* =========================
    HERO SPLIT
@@ -1795,74 +2701,46 @@ body::before{
   text-decoration: none;
   border-radius: 6px;
 }
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/style.css b/style.css
-index 847d3a12dda2f43e45eb1fe0950cb551c1dd7512..aa89008ab955711c0ab07787d6741567bc5a250f 100644
---- a/style.css
-+++ b/style.css
-@@ -282,58 +282,58 @@ h1, h2, h3 {
- .about-soap::before { content: ""; position: absolute; top: 45%; left: 30%; width: 180px; height: 180px; border-radius: 50%;
-   background: radial-gradient(circle, rgba(0,212,255,.3) 0%, rgba(0,212,255,0) 70%); filter: blur(18px); }
- .about-soap::after { content: '✨'; position: absolute; top: -10px; right: 24px; font-size: 1.5rem;
-   animation: sparkle 1.6s ease-in-out infinite; opacity: .9; }
- .about-soap span { display: none; }
- .about-soap { animation: floatSoap 5s ease-in-out infinite; align-items: flex-start; padding-top: .5rem; }
- 
- @keyframes scriptReveal { 0% { opacity: 0; transform: translateY(20px) scale(0.95); } 100% { opacity: 1; transform: translateY(0) scale(1); } }
- @keyframes underlineSweep { from { transform: scaleX(0); opacity: 0; } to { transform: scaleX(1); opacity: 1; } }
- @keyframes textReveal { to { opacity: 1; transform: translateY(0); } }
- 
- /* Quote section (unchanged) */
- .quote-form-section { padding: 4em 2em; background: linear-gradient(to bottom, #000, #333); color:#fff; text-align:center; }
- .quote-form-section h1 { font-size: 2.5rem; margin-bottom: 2rem; color:#00d4ff; }
- .quote-form { max-width: 600px; margin: 0 auto; text-align: left; }
- .quote-form label { display:block; margin-top:1.5rem; font-weight:bold; }
- .quote-form input, .quote-form textarea, .quote-form select {
-   width:100%; padding:.8em; margin-top:.5rem; border:none; border-radius:6px; background:#222; color:#fff;
- }
- .quote-form button { margin-top:2rem; padding:.8em 2em; background:#00d4ff; color:#000; font-weight:bold; border:none; border-radius:8px; cursor:pointer; transition: background .3s ease; }
- .quote-form button:hover { background:#fff; }
- 
- /* Announcement (static) */
- .announcement { width:100%; background:#000; border-bottom:1px solid rgba(255,255,255,.1);
-   padding:.9rem 1.25rem; display:flex; justify-content:center; align-items:center; z-index: 999; position: relative; }
--.announcement-inner { width:100%; max-width:1200px; display:grid; grid-template-columns:1fr auto; gap:1rem 1.5rem; align-items:center; }
-+.announcement-inner { width:100%; max-width:1200px; display:flex; flex-direction:column; align-items:center; justify-content:center;
-+  gap:.75rem; text-align:center; }
- .announce-line { color:#f2f2f2; font-size:1rem; line-height:1.35; opacity:.95; margin:0; }
--.announcement-cta { justify-self:end; display:inline-block; padding:.55em 1.2em; font-weight:800; font-size:.98rem; line-height:1;
-+.announcement-cta { display:inline-block; padding:.55em 1.2em; font-weight:800; font-size:.98rem; line-height:1;
-   border-radius:12px; background:#00d4ff; color:#000 !important; border:2px solid transparent; transition: background .2s ease, transform .2s ease; }
- .announcement-cta:hover { background:#fff; transform: translateY(-1px); }
- @media (max-width: 768px){
--  .announcement-inner { grid-template-columns:1fr; }
--  .announcement-cta { justify-self:start; }
-+  .announcement-inner { gap:.6rem; }
- }
- 
- /* iOS-only tweaks */
- html.ios .announcement { background:#f6f7f8; border-bottom:1px solid rgba(0,0,0,.1); }
- html.ios .announce-line { color:#000 !important; }
- html.ios .announcement-cta { background:#00ff88 !important; color:#000 !important; }
- html.ios .announcement-cta:hover { background:#00cc6d !important; }
- 
- html.ios .split-screen { flex-direction: column; height: auto; }
- html.ios .image-side { display: none !important; }
- html.ios .text-side {
-   background:
-     linear-gradient(135deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.6) 45%, rgba(0, 0, 0, 0.35) 100%),
-     url('cleanuptransformation.jpg') center center / cover no-repeat;
-   min-height: 100svh; padding: 4em 1.5em calc(1.5em + env(safe-area-inset-bottom));
-   display:flex; flex-direction:column; justify-content:center; align-items:flex-start;
-   border-radius:20px; overflow:hidden; position:relative;
- }
- html.ios .text-side::before { display: none; }
- html.ios .headline { font-size:3rem; line-height:1.15; font-weight:900; color:#f6fbff; position:relative; text-shadow: 0 14px 32px rgba(0,0,0,0.55); }
- html.ios .subtext { font-size:1.3rem; font-weight:600; color:#e4f4ff; max-width:30ch; position:relative; text-shadow: 0 12px 28px rgba(0,0,0,0.45); }
- html.ios .quote-btn-home, html.ios .services-btn-home {
-   background:#00d4ff !important; color:#001220 !important; border:none; border-radius:14px; font-weight:800;
-   font-size:1.4rem; padding:.8em 2em; text-transform:lowercase; transition: background .3s ease, transform .3s ease; position:relative; z-index:2;
- }
- 
-EOF
 )
+.stepper-button {
+  appearance: none;
+  border: none;
+  background: rgba(6, 22, 34, 0.6);
+  color: rgba(187, 229, 255, 0.9);
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.stepper-button span {
+  pointer-events: none;
+  transform: translateY(-1px);
+}
+
+.stepper-button:hover,
+.stepper-button:focus-visible {
+  background: rgba(0, 212, 255, 0.16);
+  color: #ffffff;
+}
+
+.stepper-button:focus-visible {
+  outline: 2px solid rgba(0, 212, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.stepper-button:active {
+  transform: translateY(1px);
+}
+
+.stepper-button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/thankyou.html
+++ b/thankyou.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Thank You!</title>
   <link rel="stylesheet" href="style.css" />
+  <script src="nav-cart.js" defer></script>
 </head>
 <body>
 
@@ -16,9 +17,47 @@
     <nav class="nav-links">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
-      <a href="quote.html" class="quote-btn">Get Quote</a>
+      <a href="book.html#start" class="quote-btn">Book Online</a>
     </nav>
+    <div class="nav-actions">
+      <button class="nav-cart" type="button" data-cart-toggle aria-haspopup="dialog" aria-controls="navCartPopover" aria-expanded="false">
+        <span class="nav-cart-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path d="M4.5 4h-2a.5.5 0 0 1 0-1h2.8a1 1 0 0 1 .97.76L6.7 6H21a1 1 0 0 1 .96 1.27l-2 7A1 1 0 0 1 19 15H9.24l-.78 2.34A1 1 0 0 1 7.52 18H4.5a.5.5 0 0 1 0-1h2.55l3.2-9.6L9.8 6H4.78a1 1 0 0 1-.95-.68L4.5 4Zm4.28 3-2.4 7.2H19.1l1.71-6H8.78ZM9 19.75a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Zm9.5 0a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Z" fill="currentColor"/>
+          </svg>
+        </span>
+        <span class="nav-cart-label">Cart</span>
+        <span class="nav-cart-count" data-cart-count hidden>0</span>
+      </button>
+    </div>
   </header>
+  <aside class="nav-cart-popover" id="navCartPopover" role="dialog" aria-modal="false" aria-label="Cart summary" hidden>
+    <div class="nav-cart-popover-inner">
+      <button type="button" class="cart-popover-close" data-cart-close aria-label="Close cart">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <header class="cart-popover-header">
+        <img data-cart-popover-image alt="Cart package preview" loading="lazy" />
+        <div>
+          <p class="cart-popover-title" data-popover-service>Your cart is empty</p>
+          <p class="cart-popover-subtitle" data-popover-frequency>Build a package to see pricing here.</p>
+        </div>
+      </header>
+      <p class="cart-popover-status" data-popover-status hidden></p>
+      <p class="cart-popover-empty" data-popover-empty>Use “Book Online” to customise your cleaning package.</p>
+      <dl class="cart-popover-details" data-popover-details hidden></dl>
+      <div class="cart-popover-totals" data-popover-totals hidden>
+        <div><span>Visit total</span><span data-popover-total>—</span></div>
+        <div><span>Deposit (50%)</span><span data-popover-deposit>—</span></div>
+        <div><span>Balance</span><span data-popover-balance>—</span></div>
+      </div>
+      <div class="cart-popover-payments" data-popover-payments hidden>
+        <div id="nav-paypal-buttons" data-paypal-container="nav"></div>
+        <p class="cart-popover-paypal-status" id="nav-paypal-status" role="status" aria-live="polite"></p>
+        <button type="button" class="btn cart-popover-google" data-google-pay-button disabled>Google Pay (coming soon)</button>
+      </div>
+    </div>
+  </aside>
 
   <section style="padding: 4em; text-align: center;">
     <h1>Thank you for reaching out!</h1>


### PR DESCRIPTION
## Summary
- widen the visit-frequency tiles and desktop form grid so the cart summary stays beside step one
- drop the on-page payment method radios and integration notes so the cart only shows the add-to-cart button and policy copy
- soften PayPal messaging and summaries to avoid exposing setup details while keeping deposit tracking intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e183836ec88320a011a1b38925ff6f